### PR TITLE
Pre-Version 2.0.0 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,49 +163,48 @@ keys.
 
 ### Regular Keys
 
-The original Chip 8 had a keypad with the numbered keys 0 - 9 and A - F (16
-keys in total). Without any modifications to the emulator, the keys are mapped
-as follows:
+he original Chip 8 had a keypad with the numbered keys 0 - 9 and A - F (16
+keys in total). The original key configuration was as follows:
 
-| Chip 8 Key | Keyboard Key |
-| :--------: | :----------: |
-| `1`        | `4`          |
-| `2`        | `5`          |
-| `3`        | `6`          |
-| `4`        | `7`          |
-| `5`        | `R`          |
-| `6`        | `T`          |
-| `7`        | `Y`          |
-| `8`        | `U`          |
-| `9`        | `F`          |
-| `0`        | `G`          |
-| `A`        | `H`          |
-| `B`        | `J`          |
-| `C`        | `V`          |
-| `D`        | `B`          |
-| `E`        | `N`          |
-| `F`        | `M`          |
+
+| `1` | `2` | `3` | `C` |
+|-----|-----|-----|-----|
+| `4` | `5` | `6` | `D` |
+| `7` | `8` | `9` | `E` |
+| `A` | `0` | `B` | `F` |
+
+The Chip8Java emulator maps them to the following keyboard keys by default:
+
+| `1` | `2` | `3` | `4` |
+|-----|-----|-----|-----|
+| `Q` | `W` | `E` | `R` |
+| `A` | `S` | `D` | `F` |
+| `Z` | `X` | `C` | `V` |
+
 
 ### Debug Keys
 
 Pressing a debug key at any time will cause the emulator to enter into a
 different mode of operation. The debug keys are:
 
-| Keyboard Key | Effect |
-| :----------: | ------ |
-| `ESC`        | Quits the emulator             |
-| `X`          | Enters CPU trace mode          |
-| `Z`          | Enters CPU trace and step mode |
-| `N`          | Next key while in step mode    |
-| `C`          | Exits CPU trace or step mode   |
+| Keyboard Key | Effect                         |
+|:------------:|--------------------------------|
+|    `ESC`     | Quits the emulator             |
+|     `O`      | Enters CPU trace mode          |
+|     `P`      | Enters CPU trace and step mode |
+|     `N`      | Next key while in step mode    |
+|     `L`      | Exits CPU trace or step mode   |
 
 ## ROM Compatibility
 
-Here are the list of public domain ROMs and their current status with the emulator.
+Here are the list of public domain ROMs and their current status with the emulator, along
+with links to public domain repositories where applicable.
 
-| ROM Name          | Works Correctly    | Notes |
-| :---------------: | :----------------: | :---: |
-| MAZE              | :heavy_check_mark: |       |
+### Chip 8 ROMs
+
+| ROM Name                                                                                          |      Working       |     Flags     | 
+|:--------------------------------------------------------------------------------------------------|:------------------:|:-------------:|
+| [down8](https://johnearnest.github.io/chip8Archive/play.html?p=down8)                             | :heavy_check_mark: |               |
 
 ## Third Party Licenses and Attributions
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -262,7 +262,7 @@ public class CentralProcessingUnit extends Thread
                 break;
 
             case 0xB:
-                jumpToIndexPlusValue();
+                jumpToRegisterPlusValue();
                 break;
 
             case 0xC:
@@ -352,6 +352,25 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * 00FB - SCRR
+     * Scrolls the screen right by 4 pixels.
+     */
+    private void scrollRight() {
+        screen.scrollRight();
+        lastOpDesc = "Scroll Right";
+    }
+
+    /**
+     * 00FC - SCRL
+     * Scrolls the screen left by 4 pixels.
+     */
+    private void scrollLeft() {
+        screen.scrollLeft();
+        lastOpDesc = "Scroll Left";
+    }
+
+    /**
+     * 00EE - RTS
      * Return from subroutine. Pop the current value in the stack pointer off of
      * the stack, and set the program counter to the value popped.
      */
@@ -364,6 +383,7 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * 1nnn - JUMP nnn
      * Jump to address.
      */
     protected void jumpToAddress() {
@@ -372,6 +392,7 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * 2nnn - CALL nnn
      * Jump to subroutine. Save the current program counter on the stack.
      */
     protected void jumpToSubroutine() {
@@ -384,201 +405,203 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * 3xnn - SKE Vx, nn
      * Skip if register contents equal to constant value. The program counter is
      * updated to skip the next instruction by advancing it by 2 bytes.
      */
     protected void skipIfRegisterEqualValue() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        if (v[sourceRegister] == (operand & 0x00FF)) {
+        int x = (operand & 0x0F00) >> 8;
+        if (v[x] == (operand & 0x00FF)) {
             pc += 2;
         }
-        lastOpDesc = "SKE V" + toHex(sourceRegister, 1) + ", " + toHex(operand & 0x00FF, 2);
+        lastOpDesc = "SKE V" + toHex(x, 1) + ", " + toHex(operand & 0x00FF, 2);
     }
 
     /**
+     * 4xnn - SKNE Vx, nn
      * Skip if register contents not equal to constant value. The program
      * counter is updated to skip the next instruction by advancing it by 2
      * bytes.
      */
     protected void skipIfRegisterNotEqualValue() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        if (v[sourceRegister] != (operand & 0x00FF)) {
+        int x = (operand & 0x0F00) >> 8;
+        if (v[x] != (operand & 0x00FF)) {
             pc += 2;
         }
-        lastOpDesc = "SKNE V" + toHex(sourceRegister, 1) + ", " + toHex(operand & 0x00FF, 2);
+        lastOpDesc = "SKNE V" + toHex(x, 1) + ", " + toHex(operand & 0x00FF, 2);
     }
 
     /**
+     * 5xy0 - SKE Vx, Vy
      * Skip if source register is equal to target register. The program counter
      * is updated to skip the next instruction by advancing it by 2 bytes.
      */
     protected void skipIfRegisterEqualRegister() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        int targetRegister = (operand & 0x00F0) >> 4;
-        if (v[sourceRegister] == v[targetRegister]) {
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        if (v[x] == v[y]) {
             pc += 2;
         }
-        lastOpDesc = "SKE V" + toHex(sourceRegister, 1) + ", V" + toHex(targetRegister, 1);
+        lastOpDesc = "SKE V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 6xnn - LOAD Vx, nn
      * Move the constant value into the specified register.
      */
     protected void moveValueToRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        v[targetRegister] = (short) (operand & 0x00FF);
-        lastOpDesc = "LOAD V" + toHex(targetRegister, 1) + ", " + toHex(operand & 0x00FF, 2);
+        int x = (operand & 0x0F00) >> 8;
+        v[x] = (short) (operand & 0x00FF);
+        lastOpDesc = "LOAD V" + toHex(x, 1) + ", " + toHex(operand & 0x00FF, 2);
     }
 
     /**
+     * 7xnn - ADD Vx, nn
      * Add the constant value to the specified register.
      */
     protected void addValueToRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int temp = v[targetRegister] + (operand & 0x00FF);
-        v[targetRegister] = (temp < 256) ? (short) temp : (short) (temp - 256);
-        lastOpDesc = "ADD V" + toHex(targetRegister, 1) + ", " + toHex(operand & 0x00FF, 2);
+        int x = (operand & 0x0F00) >> 8;
+        v[x] = (short) ((v[x] + (operand & 0x00FF)) % 256);
+        lastOpDesc = "ADD V" + toHex(x, 1) + ", " + toHex(operand & 0x00FF, 2);
     }
 
     /**
+     * 8xy0 - LOAD Vx, Vy
      * Move the value of the source register into the value of the target
      * register.
      */
     protected void moveRegisterIntoRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        v[targetRegister] = v[sourceRegister];
-        lastOpDesc = "LOAD V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        v[x] = v[y];
+        lastOpDesc = "LOAD V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy1 - OR Vx, Vy
      * Perform a logical OR operation between the source and the target
      * register, and store the result in the target register.
      */
     protected void logicalOr() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        v[targetRegister] |= v[sourceRegister];
-        lastOpDesc = "OR V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        v[x] |= v[y];
+        lastOpDesc = "OR V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy2 - AND Vx, Vy
      * Perform a logical AND operation between the source and the target
      * register, and store the result in the target register.
      */
     protected void logicalAnd() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        v[targetRegister] &= v[sourceRegister];
-        lastOpDesc = "AND V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        v[x] &= v[y];
+        lastOpDesc = "AND V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy3 - XOR Vx, Vy
      * Perform a logical XOR operation between the source and the target
      * register, and store the result in the target register.
      */
     protected void exclusiveOr() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        v[targetRegister] ^= v[sourceRegister];
-        lastOpDesc = "XOR V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        v[x] ^= v[y];
+        lastOpDesc = "XOR V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy4 - ADD Vx, Vy
      * Add the value in the source register to the value in the target register,
      * and store the result in the target register. If a carry is generated, set
      * a carry flag in register VF.
      */
     protected void addRegisterToRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        int temp = v[targetRegister] + v[sourceRegister];
-        if (temp > 255) {
-            v[targetRegister] = (short) (temp - 256);
-            v[0xF] = 1;
-        } else {
-            v[targetRegister] = (short) temp;
-            v[0xF] = 0;
-        }
-        lastOpDesc = "ADD V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        short carry = (v[x] + v[y]) > 255 ? (short) 1 : (short) 0;
+        v[x] = (short) ((v[x] + v[y]) % 256);
+        v[0xF] = carry;
+        lastOpDesc = "ADD V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy5 - SUB Vx, Vy
      * Subtract the value in the target register from the value in the source
      * register, and store the result in the target register. If a borrow is NOT
      * generated, set a carry flag in register VF.
      */
     protected void subtractRegisterFromRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        int resultValue;
-        if (v[targetRegister] > v[sourceRegister]) {
-            resultValue = v[targetRegister] - v[sourceRegister];
-            v[0xF] = 1;
-        } else {
-            resultValue = 256 + v[targetRegister] - v[sourceRegister];
-            v[0xF] = 0;
-        }
-        v[targetRegister] = (short) resultValue;
-        lastOpDesc = "SUBN V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        short borrow = (v[x] >= v[y]) ? (short) 1 : (short) 0;
+        v[x] = (v[x] >= v[y]) ? (short) (v[x] - v[y]) : (short) (256 + v[x] - v[y]);
+        v[0xF] = borrow;
+        lastOpDesc = "SUBN V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy6 - SHR Vx, Vy
      * Shift the bits in the specified register 1 bit to the right. Bit 0 will
      * be shifted into register VF.
      */
     protected void rightShift() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        v[0xF] = (short) (v[sourceRegister] & 0x1);
-        v[sourceRegister] = (short) (v[sourceRegister] >> 1);
-        lastOpDesc = "SHR V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        short bit_one = (short) (v[y] & 0x1);
+        v[x] = (short) ((v[y] >> 1) & 0xFF);
+        v[0xF] = bit_one;
+        lastOpDesc = "SHR V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xy7 - SUBN Vx, Vy
      * Subtract the value in the target register from the value in the source
      * register, and store the result in the target register. If a borrow is NOT
      * generated, set a carry flag in register VF.
      */
     protected void subtractRegisterFromRegister1() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        int sourceRegister = (operand & 0x00F0) >> 4;
-        int resultValue;
-        if (v[sourceRegister] > v[targetRegister]) {
-            resultValue = v[sourceRegister] - v[targetRegister];
-            v[0xF] = 1;
-        } else {
-            resultValue = 256 + v[sourceRegister] - v[targetRegister];
-            v[0xF] = 0;
-        }
-        v[targetRegister] = (short) resultValue;
-        lastOpDesc = "SUBN V" + toHex(targetRegister, 1) + ", V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        short not_borrow = (v[y] >= v[x]) ? (short) 1 : (short) 0;
+        v[x] = (v[y] >= v[x]) ? (short) (v[y] - v[x]) : (short) (256 + v[y] - v[x]);
+        v[0xF] = not_borrow;
+        lastOpDesc = "SUBN V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 8xyE - SHL Vx, Vy
      * Shift the bits in the specified register 1 bit to the left. Bit 7 will be
      * shifted into register VF.
      */
     protected void leftShift() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        v[0xF] = (short) ((v[sourceRegister] & 0x80) >> 8);
-        v[sourceRegister] = (short) (v[sourceRegister] << 1);
-        lastOpDesc = "SHL V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        short bit_seven = (short) ((v[y] & 0x80) >> 7);
+        v[x] = (short) ((v[y] << 1) & 0xFF);
+        v[0xF] = bit_seven;
+        lastOpDesc = "SHL V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * 9xy0 - SKNE Vx, Vy
      * Skip if source register is equal to target register. The program counter
      * is updated to skip the next instruction by advancing it by 2 bytes.
      */
     protected void skipIfRegisterNotEqualRegister() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        int targetRegister = (operand & 0x00F0) >> 4;
-        if (v[sourceRegister] != v[targetRegister]) {
+        int x = (operand & 0x0F00) >> 8;
+        int y = (operand & 0x00F0) >> 4;
+        if (v[x] != v[y]) {
             pc += 2;
         }
-        lastOpDesc = "SKNE V" + toHex(sourceRegister, 1) + ", V" + toHex(targetRegister, 1);
+        lastOpDesc = "SKNE V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
     /**
+     * Annn - LOAD I, nnn
      * Load index register with constant value.
      */
     protected void loadIndexWithValue() {
@@ -587,27 +610,30 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * Bnnn - JUMP V0 + nnn
      * Load the program counter with the memory value located at the specified
      * operand plus the value of the index register.
      */
-    protected void jumpToIndexPlusValue() {
-        pc = index + (operand & 0x0FFF);
-        lastOpDesc = "JUMP I + " + toHex(operand & 0x0FFF, 3);
+    protected void jumpToRegisterPlusValue() {
+        pc = v[0] + (operand & 0x0FFF);
+        lastOpDesc = "JUMP V0 + " + toHex(operand & 0x0FFF, 3);
     }
 
     /**
+     * Cxnn - RAND Vx, nn
      * A random number between 0 and 255 is generated. The contents of it are
      * then ANDed with the constant value passed in the operand. The result is
      * stored in the target register.
      */
     protected void generateRandomNumber() {
         int value = operand & 0x00FF;
-        int targetRegister = (operand & 0x0F00) >> 8;
-        v[targetRegister] = (short) (value & random.nextInt(256));
-        lastOpDesc = "RAND V" + toHex(targetRegister, 1) + ", " + toHex(value, 2);
+        int x = (operand & 0x0F00) >> 8;
+        v[x] = (short) (value & random.nextInt(256));
+        lastOpDesc = "RAND V" + toHex(x, 1) + ", " + toHex(value, 2);
     }
 
     /**
+     * Dxyn - DRAW x, y, num_bytes
      * Draws the sprite pointed to in the index register at the specified x and
      * y coordinates. Drawing is done via an XOR routine, meaning that if the
      * target pixel is already turned on, and a pixel is set to be turned on at
@@ -661,20 +687,21 @@ public class CentralProcessingUnit extends Thread
                     boolean turnOn = (colorByte & mask) > 0;
                     boolean currentOn = screen.pixelOn(xCoord, yCoord);
 
-                    if (turnOn && currentOn) {
-                        v[0xF] |= 1;
-                        turnOn = false;
-                    } else if (!turnOn && currentOn) {
-                        turnOn = true;
-                    }
-
-                    screen.drawPixel(xCoord, yCoord, turnOn);
+                    v[0xF] += (turnOn && currentOn) ? (short) 1 : (short) 0;
+                    screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);
                     mask = mask >> 1;
                 }
             }
         }
     }
 
+    /**
+     * Draws a sprite on the screen while in NORMAL mode.
+     *
+     * @param xPos the X position of the sprite
+     * @param yPos the Y position of the sprite
+     * @param numBytes the number of bytes to draw
+     */
     private void drawNormalSprite(int xPos, int yPos, int numBytes) {
         for (int yIndex = 0; yIndex < numBytes; yIndex++) {
             short colorByte = memory.read(index + yIndex);
@@ -690,60 +717,58 @@ public class CentralProcessingUnit extends Thread
                 boolean turnOn = (colorByte & mask) > 0;
                 boolean currentOn = screen.pixelOn(xCoord, yCoord);
 
-                if (turnOn && currentOn) {
-                    v[0xF] |= 1;
-                    turnOn = false;
-                } else if (!turnOn && currentOn) {
-                    turnOn = true;
-                }
-
-                screen.drawPixel(xCoord, yCoord, turnOn);
+                v[0xF] |= (turnOn && currentOn) ? (short) 1 : (short) 0;
+                screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);
                 mask = mask >> 1;
             }
         }
     }
 
     /**
+     * Ex9E - SKPR Vx
      * Check to see if the key specified in the source register is pressed, and
      * if it is, skips the next instruction.
      */
     protected void skipIfKeyPressed() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        int keyToCheck = v[sourceRegister];
+        int x = (operand & 0x0F00) >> 8;
+        int keyToCheck = v[x];
         if (keyboard.getCurrentKey() == keyToCheck) {
             pc += 2;
         }
-        lastOpDesc = "SKPR V" + toHex(sourceRegister, 1);
+        lastOpDesc = "SKPR V" + toHex(x, 1);
     }
 
     /**
+     * ExA1 - SKUP Vx
      * Check for the specified keypress in the source register and if it is NOT
      * pressed, will skip the next instruction.
      */
     protected void skipIfKeyNotPressed() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        int keyToCheck = v[sourceRegister];
+        int x = (operand & 0x0F00) >> 8;
+        int keyToCheck = v[x];
         if (keyboard.getCurrentKey() != keyToCheck) {
             pc += 2;
         }
-        lastOpDesc = "SKUP V" + toHex(sourceRegister, 1);
+        lastOpDesc = "SKUP V" + toHex(x, 1);
     }
 
     /**
+     * Fx07 - LOAD Vx, DELAY
      * Move the value of the delay timer into the target register.
      */
     protected void moveDelayTimerIntoRegister() {
-        int targetRegister = (operand & 0x0F00) >> 8;
-        v[targetRegister] = delay;
-        lastOpDesc = "LOAD V" + toHex(targetRegister, 1) + ", DELAY";
+        int x = (operand & 0x0F00) >> 8;
+        v[x] = delay;
+        lastOpDesc = "LOAD V" + toHex(x, 1) + ", DELAY";
     }
 
     /**
+     * Fx0A - KEYD Vx
      * Stop execution until a key is pressed. Move the value of the key pressed
      * into the specified register.
      */
     protected void waitForKeypress() {
-        int targetRegister = (operand & 0x0F00) >> 8;
+        int x = (operand & 0x0F00) >> 8;
         int currentKey = keyboard.getCurrentKey();
         while (currentKey == 0) {
             try {
@@ -753,62 +778,68 @@ public class CentralProcessingUnit extends Thread
             }
             currentKey = keyboard.getCurrentKey();
         }
-        v[targetRegister] = (short) currentKey;
-        lastOpDesc = "KEYD V" + toHex(targetRegister, 1);
+        v[x] = (short) currentKey;
+        lastOpDesc = "KEYD V" + toHex(x, 1);
     }
 
     /**
+     * Fx15 - LOAD DELAY, Vx
      * Move the value stored in the specified source register into the delay
      * timer.
      */
     protected void moveRegisterIntoDelayRegister() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        delay = v[sourceRegister];
-        lastOpDesc = "LOAD DELAY, V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        delay = v[x];
+        lastOpDesc = "LOAD DELAY, V" + toHex(x, 1);
     }
 
     /**
+     * Fx18 - LOAD SOUND, Vx
      * Move the value stored in the specified source register into the sound
      * timer.
      */
     protected void moveRegisterIntoSoundRegister() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        sound = v[sourceRegister];
-        lastOpDesc = "LOAD SOUND, V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        sound = v[x];
+        lastOpDesc = "LOAD SOUND, V" + toHex(x, 1);
     }
 
     /**
+     * Fx1E - ADD I, Vx
+     * Add the value of the register into the index register value.
+     */
+    protected void addRegisterIntoIndex() {
+        int x = (operand & 0x0F00) >> 8;
+        index += v[x];
+        lastOpDesc = "ADD I, V" + toHex(x, 1);
+    }
+
+    /**
+     * Fx29 - LOAD I, Vx
      * Load the index with the sprite indicated in the source register. All
      * sprites are 5 bytes long, so the location of the specified sprite is its
      * index multiplied by 5.
      */
     protected void loadIndexWithSprite() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        index = v[sourceRegister] * 5;
-        lastOpDesc = "LOAD I, V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        index = v[x] * 5;
+        lastOpDesc = "LOAD I, V" + toHex(x, 1);
     }
 
     /**
+     * Fx30 - LOAD I, Vx
      * Load the index with the sprite indicated in the source register. All
      * sprites are 10 bytes long, so the location of the specified sprite is its
      * index multiplied by 10.
      */
     protected void loadIndexWithExtendedSprite() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        index = v[sourceRegister] * 10;
-        lastOpDesc = "LOADEXT I, V" + toHex(sourceRegister, 1);
+        int x = (operand & 0x0F00) >> 8;
+        index = v[x] * 10;
+        lastOpDesc = "LOADEXT I, V" + toHex(x, 1);
     }
 
     /**
-     * Add the value of the register into the index register value.
-     */
-    protected void addRegisterIntoIndex() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        index += v[sourceRegister];
-        lastOpDesc = "ADD I, V" + toHex(sourceRegister, 1);
-    }
-
-    /**
+     * Fx33 - BCD Vx
      * Take the value stored in source and place the digits in the following
      * locations:
      * <p>
@@ -822,40 +853,58 @@ public class CentralProcessingUnit extends Thread
      * self.memory[index + 2]
      */
     protected void storeBCDInMemory() {
-        int sourceRegister = (operand & 0x0F00) >> 8;
-        int bcdValue = v[sourceRegister];
+        int x = (operand & 0x0F00) >> 8;
+        int bcdValue = v[x];
         memory.write(bcdValue / 100, index);
         memory.write((bcdValue % 100) / 10, index + 1);
         memory.write((bcdValue % 100) % 10, index + 2);
-        lastOpDesc = "BCD V" + toHex(sourceRegister, 1) + " (" + bcdValue + ")";
+        lastOpDesc = "BCD V" + toHex(x, 1) + " (" + bcdValue + ")";
     }
 
     /**
-     * Store all of the V registers in the memory pointed to by the index
-     * register. The source register contains the number of V registers to
-     * store. For example, to store all of the V registers, the source register
-     * would contain the value 0xF.
+     * Fn55 - STOR [I]
+     * Store the V registers in the memory pointed to by the index
+     * register.
      */
     protected void storeRegistersInMemory() {
-        int numRegisters = (operand & 0x0F00) >> 8;
-        for (int counter = 0; counter <= numRegisters; counter++) {
+        int n = (operand & 0x0F00) >> 8;
+        for (int counter = 0; counter <= n; counter++) {
             memory.write(v[counter], index + counter);
         }
-        lastOpDesc = "STOR " + toHex(numRegisters, 1);
+        lastOpDesc = "STOR " + toHex(n, 1);
     }
 
     /**
-     * Read all of the V registers from the memory pointed to by the index
-     * register. The source register contains the number of V registers to load.
-     * For example, to load all of the V registers, the source register would
-     * contain the value 0xF.
+     * Fn65 - LOAD V, I
+     * Read the V registers from the memory pointed to by the index
+     * register.
      */
     protected void readRegistersFromMemory() {
-        int numRegisters = (operand & 0x0F00) >> 8;
-        for (int counter = 0; counter <= numRegisters; counter++) {
+        int n = (operand & 0x0F00) >> 8;
+        for (int counter = 0; counter <= n; counter++) {
             v[counter] = memory.read(index + counter);
         }
-        lastOpDesc = "READ " + toHex(numRegisters, 1);
+        lastOpDesc = "READ " + toHex(n, 1);
+    }
+
+    /**
+     * Fn75 - STORRPL n
+     * Stores the values from the V registers into the RPL registers.
+     */
+    protected void storeRegistersInRPL() {
+        int n = (operand & 0x0F00) >> 8;
+        System.arraycopy(v, 0, rpl, 0, n + 1);
+        lastOpDesc = "STORRPL " + toHex(n, 1);
+    }
+
+    /**
+     * Fn85 - READRPL n
+     * Reads the values from the RPL registers back into the V registers.
+     */
+    protected void readRegistersFromRPL() {
+        int n = (operand & 0x0F00) >> 8;
+        System.arraycopy(rpl, 0, v, 0, n + 1);
+        lastOpDesc = "READRPL " + toHex(n, 1);
     }
 
     /**
@@ -879,9 +928,8 @@ public class CentralProcessingUnit extends Thread
      * Decrement the delay timer and the sound timer if they are not zero.
      */
     private void decrementTimers() {
-        if (delay != 0) {
-            delay--;
-        }
+        delay -= (delay != 0) ? (short) 1 : (short) 0;
+
         if (sound != 0) {
             sound--;
             midiChannel.noteOn(60, 50);
@@ -905,40 +953,6 @@ public class CentralProcessingUnit extends Thread
     private void disableExtendedMode() {
         screen.setNormalScreenMode();
         mode = MODE_NORMAL;
-    }
-
-    /**
-     * Scrolls the screen left by 4 pixels.
-     */
-    private void scrollLeft() {
-        screen.scrollLeft();
-        lastOpDesc = "Scroll Left";
-    }
-
-    /**
-     * Scrolls the screen right by 4 pixels.
-     */
-    private void scrollRight() {
-        screen.scrollRight();
-        lastOpDesc = "Scroll Right";
-    }
-
-    /**
-     * Stores the values from the V registers into the RPL registers.
-     */
-    protected void storeRegistersInRPL() {
-        int numRegisters = (operand & 0x0F00) >> 8;
-        System.arraycopy(v, 0, rpl, 0, numRegisters + 1);
-        lastOpDesc = "STORRPL " + toHex(numRegisters, 1);
-    }
-
-    /**
-     * Reads the values from the RPL registers back into the V register.
-     */
-    protected void readRegistersFromRPL() {
-        int numRegisters = (operand & 0x0F00) >> 8;
-        System.arraycopy(rpl, 0, v, 0, numRegisters + 1);
-        lastOpDesc = "READRPL " + toHex(numRegisters, 1);
     }
 
     /**

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -685,7 +685,7 @@ public class CentralProcessingUnit extends Thread
                     xCoord = xCoord % screen.getWidth();
 
                     boolean turnOn = (colorByte & mask) > 0;
-                    boolean currentOn = screen.pixelOn(xCoord, yCoord);
+                    boolean currentOn = screen.getPixel(xCoord, yCoord);
 
                     v[0xF] += (turnOn && currentOn) ? (short) 1 : (short) 0;
                     screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);
@@ -715,7 +715,7 @@ public class CentralProcessingUnit extends Thread
                 xCoord = xCoord % screen.getWidth();
 
                 boolean turnOn = (colorByte & mask) > 0;
-                boolean currentOn = screen.pixelOn(xCoord, yCoord);
+                boolean currentOn = screen.getPixel(xCoord, yCoord);
 
                 v[0xF] |= (turnOn && currentOn) ? (short) 1 : (short) 0;
                 screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
@@ -250,8 +250,8 @@ public class Emulator
      */
     private void attachCanvas() {
         int scaleFactor = screen.getScale();
-        int scaledWidth = screen.getWidth() * scaleFactor;
-        int scaledHeight = screen.getHeight() * scaleFactor;
+        int scaledWidth = Screen.WIDTH * scaleFactor;
+        int scaledHeight = Screen.HEIGHT * scaleFactor;
 
         JPanel panel = (JPanel) container.getContentPane();
         panel.removeAll();

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Keyboard.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Keyboard.java
@@ -15,25 +15,26 @@ public class Keyboard extends KeyAdapter
 {
     // Map from a keypress event to key values
     public static final int[] sKeycodeMap = {
-            KeyEvent.VK_4, // Key 1
-            KeyEvent.VK_5, // Key 2
-            KeyEvent.VK_6, // Key 3
-            KeyEvent.VK_7, // Key 4
-            KeyEvent.VK_R, // Key 5
-            KeyEvent.VK_Y, // Key 6
-            KeyEvent.VK_U, // Key 7
-            KeyEvent.VK_F, // Key 8
-            KeyEvent.VK_G, // Key 9
-            KeyEvent.VK_H, // Key A
-            KeyEvent.VK_J, // Key B
-            KeyEvent.VK_V, // Key C
-            KeyEvent.VK_B, // Key D
-            KeyEvent.VK_N, // Key E
-            KeyEvent.VK_M, // Key F
+            KeyEvent.VK_X, // 0x0
+            KeyEvent.VK_1, // 0x1
+            KeyEvent.VK_2, // 0x2
+            KeyEvent.VK_3, // 0x3
+            KeyEvent.VK_Q, // 0x4
+            KeyEvent.VK_W, // 0x5
+            KeyEvent.VK_E, // 0x6
+            KeyEvent.VK_A, // 0x7
+            KeyEvent.VK_S, // 0x8
+            KeyEvent.VK_D, // 0x9
+            KeyEvent.VK_Z, // 0xA
+            KeyEvent.VK_C, // 0xB
+            KeyEvent.VK_4, // 0xC
+            KeyEvent.VK_R, // 0xD
+            KeyEvent.VK_F, // 0xE
+            KeyEvent.VK_V, // 0xF
     };
 
-    // The current key being pressed, 0 if no key
-    protected int currentKeyPressed = 0;
+    // The current key being pressed, -1 if no key
+    protected int currentKeyPressed = -1;
 
     // Stores the last debug key keypress
     protected int debugKeyPressed;
@@ -42,13 +43,13 @@ public class Keyboard extends KeyAdapter
     protected static final int CHIP8_QUIT = KeyEvent.VK_ESCAPE;
 
     // The key to enter debug mode
-    public static final int CHIP8_STEP = KeyEvent.VK_Z;
+    public static final int CHIP8_STEP = KeyEvent.VK_P;
 
     // The key to enter trace mode
-    public static final int CHIP8_TRACE = KeyEvent.VK_X;
+    public static final int CHIP8_TRACE = KeyEvent.VK_O;
 
     // The key to stop trace or debug
-    public static final int CHIP8_NORMAL = KeyEvent.VK_C;
+    public static final int CHIP8_NORMAL = KeyEvent.VK_L;
 
     // The key to advance to the next instruction
     public static final int CHIP8_NEXT = KeyEvent.VK_N;
@@ -63,25 +64,21 @@ public class Keyboard extends KeyAdapter
     public void keyPressed(KeyEvent e) {
         debugKeyPressed = e.getKeyCode();
 
-        switch (debugKeyPressed) {
-            case CHIP8_QUIT:
-                emulator.kill();
-                break;
-
-            default:
-                currentKeyPressed = mapKeycodeToChip8Key(e.getKeyCode());
-                break;
+        if (debugKeyPressed == CHIP8_QUIT) {
+            emulator.kill();
         }
+
+        currentKeyPressed = mapKeycodeToChip8Key(debugKeyPressed);
     }
 
     @Override
     public void keyReleased(KeyEvent e) {
-        currentKeyPressed = 0;
+        currentKeyPressed = -1;
     }
 
     /**
      * Map a keycode value to a Chip 8 key value. See sKeycodeMap definition. Will
-     * return 0 if no Chip8 key was pressed. In the case of multiple keys being
+     * return -1 if no Chip8 key was pressed. In the case of multiple keys being
      * pressed simultaneously, will return the first one that it finds in the
      * keycode mapping object.
      *
@@ -91,10 +88,10 @@ public class Keyboard extends KeyAdapter
     public int mapKeycodeToChip8Key(int keycode) {
         for (int i = 0; i < sKeycodeMap.length; i++) {
             if (sKeycodeMap[i] == keycode) {
-                return i + 1;
+                return i;
             }
         }
-        return 0;
+        return -1;
     }
 
     /**

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -1124,14 +1124,14 @@ public class CentralProcessingUnitTest
         cpu.v[1] = 0;
         cpu.operand = 0x11;
         cpu.drawSprite();
-        assertTrue(screen.pixelOn(0, 0));
-        assertFalse(screen.pixelOn(1, 0));
-        assertTrue(screen.pixelOn(2, 0));
-        assertFalse(screen.pixelOn(3, 0));
-        assertTrue(screen.pixelOn(4, 0));
-        assertFalse(screen.pixelOn(5, 0));
-        assertTrue(screen.pixelOn(6, 0));
-        assertFalse(screen.pixelOn(7, 0));
+        assertTrue(screen.getPixel(0, 0));
+        assertFalse(screen.getPixel(1, 0));
+        assertTrue(screen.getPixel(2, 0));
+        assertFalse(screen.getPixel(3, 0));
+        assertTrue(screen.getPixel(4, 0));
+        assertFalse(screen.getPixel(5, 0));
+        assertTrue(screen.getPixel(6, 0));
+        assertFalse(screen.getPixel(7, 0));
         tearDownCanvas();
     }
 
@@ -1149,22 +1149,22 @@ public class CentralProcessingUnitTest
         cpu.enableExtendedMode();
         cpu.drawSprite();
         for (int byteOffset = 0; byteOffset < 16; byteOffset++) {
-            assertTrue(screen.pixelOn(0, byteOffset));
-            assertFalse(screen.pixelOn(1, byteOffset));
-            assertTrue(screen.pixelOn(2, byteOffset));
-            assertFalse(screen.pixelOn(3, byteOffset));
-            assertTrue(screen.pixelOn(4, byteOffset));
-            assertFalse(screen.pixelOn(5, byteOffset));
-            assertTrue(screen.pixelOn(6, byteOffset));
-            assertFalse(screen.pixelOn(7, byteOffset));
-            assertTrue(screen.pixelOn(8, byteOffset));
-            assertFalse(screen.pixelOn(9, byteOffset));
-            assertTrue(screen.pixelOn(10, byteOffset));
-            assertFalse(screen.pixelOn(11, byteOffset));
-            assertTrue(screen.pixelOn(12, byteOffset));
-            assertFalse(screen.pixelOn(13, byteOffset));
-            assertTrue(screen.pixelOn(14, byteOffset));
-            assertFalse(screen.pixelOn(15, byteOffset));
+            assertTrue(screen.getPixel(0, byteOffset));
+            assertFalse(screen.getPixel(1, byteOffset));
+            assertTrue(screen.getPixel(2, byteOffset));
+            assertFalse(screen.getPixel(3, byteOffset));
+            assertTrue(screen.getPixel(4, byteOffset));
+            assertFalse(screen.getPixel(5, byteOffset));
+            assertTrue(screen.getPixel(6, byteOffset));
+            assertFalse(screen.getPixel(7, byteOffset));
+            assertTrue(screen.getPixel(8, byteOffset));
+            assertFalse(screen.getPixel(9, byteOffset));
+            assertTrue(screen.getPixel(10, byteOffset));
+            assertFalse(screen.getPixel(11, byteOffset));
+            assertTrue(screen.getPixel(12, byteOffset));
+            assertFalse(screen.getPixel(13, byteOffset));
+            assertTrue(screen.getPixel(14, byteOffset));
+            assertFalse(screen.getPixel(15, byteOffset));
         }
         tearDownCanvas();
     }
@@ -1181,14 +1181,14 @@ public class CentralProcessingUnitTest
         cpu.drawSprite();
         cpu.drawSprite();
         assertEquals(1, cpu.v[0xF]);
-        assertFalse(screen.pixelOn(0, 0));
-        assertFalse(screen.pixelOn(1, 0));
-        assertFalse(screen.pixelOn(2, 0));
-        assertFalse(screen.pixelOn(3, 0));
-        assertFalse(screen.pixelOn(4, 0));
-        assertFalse(screen.pixelOn(5, 0));
-        assertFalse(screen.pixelOn(6, 0));
-        assertFalse(screen.pixelOn(7, 0));
+        assertFalse(screen.getPixel(0, 0));
+        assertFalse(screen.getPixel(1, 0));
+        assertFalse(screen.getPixel(2, 0));
+        assertFalse(screen.getPixel(3, 0));
+        assertFalse(screen.getPixel(4, 0));
+        assertFalse(screen.getPixel(5, 0));
+        assertFalse(screen.getPixel(6, 0));
+        assertFalse(screen.getPixel(7, 0));
         tearDownCanvas();
     }
 
@@ -1207,22 +1207,22 @@ public class CentralProcessingUnitTest
         cpu.drawSprite();
         cpu.drawSprite();
         for (int byteOffset = 0; byteOffset < 16; byteOffset++) {
-            assertFalse(screen.pixelOn(0, byteOffset));
-            assertFalse(screen.pixelOn(1, byteOffset));
-            assertFalse(screen.pixelOn(2, byteOffset));
-            assertFalse(screen.pixelOn(3, byteOffset));
-            assertFalse(screen.pixelOn(4, byteOffset));
-            assertFalse(screen.pixelOn(5, byteOffset));
-            assertFalse(screen.pixelOn(6, byteOffset));
-            assertFalse(screen.pixelOn(7, byteOffset));
-            assertFalse(screen.pixelOn(8, byteOffset));
-            assertFalse(screen.pixelOn(9, byteOffset));
-            assertFalse(screen.pixelOn(10, byteOffset));
-            assertFalse(screen.pixelOn(11, byteOffset));
-            assertFalse(screen.pixelOn(12, byteOffset));
-            assertFalse(screen.pixelOn(13, byteOffset));
-            assertFalse(screen.pixelOn(14, byteOffset));
-            assertFalse(screen.pixelOn(15, byteOffset));
+            assertFalse(screen.getPixel(0, byteOffset));
+            assertFalse(screen.getPixel(1, byteOffset));
+            assertFalse(screen.getPixel(2, byteOffset));
+            assertFalse(screen.getPixel(3, byteOffset));
+            assertFalse(screen.getPixel(4, byteOffset));
+            assertFalse(screen.getPixel(5, byteOffset));
+            assertFalse(screen.getPixel(6, byteOffset));
+            assertFalse(screen.getPixel(7, byteOffset));
+            assertFalse(screen.getPixel(8, byteOffset));
+            assertFalse(screen.getPixel(9, byteOffset));
+            assertFalse(screen.getPixel(10, byteOffset));
+            assertFalse(screen.getPixel(11, byteOffset));
+            assertFalse(screen.getPixel(12, byteOffset));
+            assertFalse(screen.getPixel(13, byteOffset));
+            assertFalse(screen.getPixel(14, byteOffset));
+            assertFalse(screen.getPixel(15, byteOffset));
         }
         tearDownCanvas();
     }
@@ -1240,14 +1240,14 @@ public class CentralProcessingUnitTest
         memory.write(0x00, 0x200);
         cpu.drawSprite();
         assertEquals(0, cpu.v[0xF]);
-        assertTrue(screen.pixelOn(0, 0));
-        assertTrue(screen.pixelOn(1, 0));
-        assertTrue(screen.pixelOn(2, 0));
-        assertTrue(screen.pixelOn(3, 0));
-        assertTrue(screen.pixelOn(4, 0));
-        assertTrue(screen.pixelOn(5, 0));
-        assertTrue(screen.pixelOn(6, 0));
-        assertTrue(screen.pixelOn(7, 0));
+        assertTrue(screen.getPixel(0, 0));
+        assertTrue(screen.getPixel(1, 0));
+        assertTrue(screen.getPixel(2, 0));
+        assertTrue(screen.getPixel(3, 0));
+        assertTrue(screen.getPixel(4, 0));
+        assertTrue(screen.getPixel(5, 0));
+        assertTrue(screen.getPixel(6, 0));
+        assertTrue(screen.getPixel(7, 0));
         tearDownCanvas();
     }
 }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/KeyboardTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/KeyboardTest.java
@@ -21,7 +21,7 @@ public class KeyboardTest
     private Keyboard keyboard;
     private Emulator emulator;
     private KeyEvent event;
-    private static final int KEY_NOT_IN_MAPPING = KeyEvent.VK_A;
+    private static final int KEY_NOT_IN_MAPPING = KeyEvent.VK_H;
     
     @Before
     public void setUp() {
@@ -33,18 +33,18 @@ public class KeyboardTest
     @Test
     public void testMapKeycodeToChip8Key() {
         for (int index = 0; index < Keyboard.sKeycodeMap.length; index++) {
-            assertEquals(index + 1, keyboard.mapKeycodeToChip8Key(Keyboard.sKeycodeMap[index]));
+            assertEquals(index, keyboard.mapKeycodeToChip8Key(Keyboard.sKeycodeMap[index]));
         }
     }
     
     @Test
     public void testMapKeycodeToChip8KeyReturnsZeroOnInvalidKey() {
-        assertEquals(0, keyboard.mapKeycodeToChip8Key(KEY_NOT_IN_MAPPING));
+        assertEquals(-1, keyboard.mapKeycodeToChip8Key(KEY_NOT_IN_MAPPING));
     }
     
     @Test
     public void testCurrentKeyIsZeroWhenNoKeyPressed() {
-        assertEquals(0, keyboard.getCurrentKey());
+        assertEquals(-1, keyboard.getCurrentKey());
     }
 
     @Test
@@ -57,12 +57,12 @@ public class KeyboardTest
     public void testKeyReleased() {
         keyboard.currentKeyPressed = 1;
         keyboard.keyReleased(null);
-        assertEquals(0, keyboard.currentKeyPressed);
+        assertEquals(-1, keyboard.currentKeyPressed);
     }
 
     @Test
     public void testKeyPressedWorksCorrectly() {
-        when(event.getKeyCode()).thenReturn(KeyEvent.VK_5);
+        when(event.getKeyCode()).thenReturn(KeyEvent.VK_2);
         keyboard.keyPressed(event);
         assertEquals(2, keyboard.currentKeyPressed);
     }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
@@ -26,34 +26,46 @@ public class ScreenTest
 
     @Test
     public void testDefaultConstructorSetsCorrectWidth() {
-        assertEquals(Screen.normalScreenMode.getWidth(), screen.getWidth());
+        assertEquals(64, screen.getWidth());
     }
 
     @Test
     public void testDefaultConstructorSetsCorrectHeight() {
-        assertEquals(Screen.normalScreenMode.getHeight(), screen.getHeight());
+        assertEquals(32, screen.getHeight());
+    }
+
+    @Test
+    public void testExtendedModeSetsCorrectWidth() {
+        screen.setExtendedScreenMode();
+        assertEquals(128, screen.getWidth());
+    }
+
+    @Test
+    public void testExtendedModeSetsCorrectHeight() {
+        screen.setExtendedScreenMode();
+        assertEquals(64, screen.getHeight());
     }
 
     @Test
     public void testScaleFactorSetCorrectlyOnDefault() {
-        assertEquals(Screen.normalScreenMode.getScale(), screen.getScale());
+        assertEquals(1, screen.getScale());
     }
 
     @Test
     public void testScreenNoPixelsOnAtInit() {
         for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                assertFalse(screen.pixelOn(xCoord, yCoord));
+                assertFalse(screen.getPixel(xCoord, yCoord));
             }
         }
     }
 
     @Test
-    public void testScreenTurningPixelsOnSetsPixelOn() {
+    public void testScreenTurningPixelsOnSetsGetPixel() {
         for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
                 screen.drawPixel(xCoord, yCoord, true);
-                assertTrue(screen.pixelOn(xCoord, yCoord));
+                assertTrue(screen.getPixel(xCoord, yCoord));
             }
         }
     }
@@ -64,22 +76,22 @@ public class ScreenTest
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
                 screen.drawPixel(xCoord, yCoord, true);
                 screen.drawPixel(xCoord, yCoord, false);
-                assertFalse(screen.pixelOn(xCoord, yCoord));
+                assertFalse(screen.getPixel(xCoord, yCoord));
             }
         }
     }
 
     @Test
     public void testClearScreenSetsAllPixelsOff() {
-        for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
-            for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
+        for (int xCoord = 0; xCoord < 64; xCoord++) {
+            for (int yCoord = 0; yCoord < 32; yCoord++) {
                 screen.drawPixel(xCoord, yCoord, true);
             }
         }
         screen.clearScreen();
-        for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
+        for (int xCoord = 0; xCoord < 64; xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                assertFalse(screen.pixelOn(xCoord, yCoord));
+                assertFalse(screen.getPixel(xCoord, yCoord));
             }
         }
     }
@@ -101,8 +113,8 @@ public class ScreenTest
         screen = new Screen(2);
         screen.drawPixel(0, 0, true);
         screen.scrollRight();
-        assertTrue(screen.pixelOn(4,0));
-        assertFalse(screen.pixelOn(0,0));
+        assertTrue(screen.getPixel(4,0));
+        assertFalse(screen.getPixel(0,0));
     }
 
     @Test
@@ -110,8 +122,8 @@ public class ScreenTest
         screen = new Screen(2);
         screen.drawPixel(4, 0, true);
         screen.scrollLeft();
-        assertTrue(screen.pixelOn(0, 0));
-        assertFalse(screen.pixelOn(4, 0));
+        assertTrue(screen.getPixel(0, 0));
+        assertFalse(screen.getPixel(4, 0));
     }
 
     @Test
@@ -119,8 +131,8 @@ public class ScreenTest
         screen = new Screen(2);
         screen.drawPixel(0, 0, true);
         screen.scrollDown(4);
-        assertTrue(screen.pixelOn(0, 4));
-        assertFalse(screen.pixelOn(0, 0));
+        assertTrue(screen.getPixel(0, 4));
+        assertFalse(screen.getPixel(0, 0));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a number of small issues with the emulator prior to a full V2.0.0 release. Fixes include:

* Fixed a problem with screen drawing pixel routines crashing on various edge conditions.
* Fixed register shifting not putting the correct bit in the `F` register.
* Updated screen routines to use a single size window while in normal and extended mode.
* Updated keybindings to reflect the same keys used by Octo and other popular emulators.
* Fixed a problem with key mapping not mapping all the original Chip 8 keys.

Unit tests updated to catch new failures, and updated to reflect refactored changes.