### PR TITLE
Add pitch register and load pitch instruction

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,4 +18,6 @@ jobs:
     - name: Build with Gradle
       run: xvfb-run --auto-servernum ./gradlew build
     - name: Codecov
-      uses: codecov/codecov-action@v3.1.0
+      uses: codecov/codecov-action@v4.2.0
+      env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -68,6 +68,12 @@ public class CentralProcessingUnit extends Thread
     // The current operand
     protected int operand;
 
+    // The current pitch
+    protected int pitch;
+
+    // The current sound playback rate
+    protected double playbackRate;
+
     // The internal memory for the Chip 8
     private final Memory memory;
 
@@ -321,6 +327,10 @@ public class CentralProcessingUnit extends Thread
 
                     case 0x33:
                         storeBCDInMemory();
+                        break;
+
+                    case 0x3A:
+                        loadPitch();
                         break;
 
                     case 0x55:
@@ -862,6 +872,17 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * Fx3A - Pitch Vx
+     * Loads the value from register x into the pitch register.
+     */
+    protected void loadPitch() {
+        int x = (operand & 0x0F00) >> 8;
+        pitch = v[x];
+        playbackRate = 4000 * Math.pow(2.0, ((pitch - 64) / 48));
+        lastOpDesc = "PITCH V" + toHex(x, 1) + " (" + v[x] + ")";
+    }
+
+    /**
      * Fn55 - STOR [I]
      * Store the V registers in the memory pointed to by the index
      * register.
@@ -919,6 +940,8 @@ public class CentralProcessingUnit extends Thread
         index = 0;
         delay = 0;
         sound = 0;
+        pitch = 64;
+        playbackRate = 4000.0;
         if (screen != null) {
             screen.clearScreen();
         }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -943,6 +943,7 @@ public class CentralProcessingUnitTest
             if ((subfunction != 0x07) && (subfunction != 0x0A) &&
                     (subfunction != 0x15) && (subfunction != 0x18) &&
                     (subfunction != 0x1E) && (subfunction != 0x29) &&
+                    (subfunction != 0x3A) &&
                     (subfunction != 0x33) && (subfunction != 0x55) &&
                     (subfunction != 0x65) && (subfunction != 0x30) &&
                     (subfunction != 0x75) && (subfunction != 0x85)) {
@@ -977,12 +978,12 @@ public class CentralProcessingUnitTest
         assertEquals("CLS", cpu.getOpShortDesc());
     }
 
-//    @Test
-//    public void testKillInvoked() {
-//        cpu.operand = 0xFD;
-//        cpu.executeInstruction(0x0);
-//        assertFalse(cpu.isAlive());
-//    }
+    @Test
+    public void testKillInvoked() {
+        cpu.operand = 0xFD;
+        cpu.executeInstruction(0x0);
+        assertFalse(cpu.isAlive());
+    }
 
     @Test
     public void testEnableExtendedScreenMode() {
@@ -1047,6 +1048,31 @@ public class CentralProcessingUnitTest
         cpu.executeInstruction(0x0);
         verify(screenMock, times(1)).scrollRight();
         assertEquals("Scroll Right", cpu.lastOpDesc);
+    }
+
+    @Test
+    public void testPitchInit64() {
+        assertEquals(64, cpu.pitch);
+        assertEquals(4000.0, cpu.playbackRate, 0.001);
+    }
+
+    @Test
+    public void testLoadPitch() {
+        cpu.v[1] = (short) 112;
+        cpu.operand = 0xF13A;
+        cpu.loadPitch();
+        assertEquals(112, cpu.pitch);
+        assertEquals(8000.0, cpu.playbackRate, 0.001);
+    }
+
+    @Test
+    public void testLoadPitchIntegration() {
+        cpu.v[1] = 112;
+        memory.write(0xF1, 0x0200);
+        memory.write(0x3A, 0x0201);
+        cpu.fetchIncrementExecute();
+        assertEquals(112, cpu.pitch);
+        assertEquals(8000.0, cpu.playbackRate, 0.001);
     }
     
     @Test


### PR DESCRIPTION
This PR adds a new `pitch` register to the CPU, as well as adds a playback rate value (for the future use of the sound functions). Unit and integration tests added to catch new conditions. This PR closes #29 