### PR TITLE
Bitplane drawing

### DIFF
--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -152,7 +152,7 @@ public class CentralProcessingUnit extends Thread
             case 0x0:
                 switch (operand & 0x00FF) {
                     case 0xE0:
-                        screen.clearScreen();
+                        screen.clearScreen(bitplane);
                         lastOpDesc = "CLS";
                         break;
 
@@ -387,7 +387,7 @@ public class CentralProcessingUnit extends Thread
      * Scrolls the screen right by 4 pixels.
      */
     private void scrollRight() {
-        screen.scrollRight();
+        screen.scrollRight(bitplane);
         lastOpDesc = "Scroll Right";
     }
 
@@ -396,7 +396,7 @@ public class CentralProcessingUnit extends Thread
      * Scrolls the screen left by 4 pixels.
      */
     private void scrollLeft() {
-        screen.scrollLeft();
+        screen.scrollLeft(bitplane);
         lastOpDesc = "Scroll Left";
     }
 
@@ -699,10 +699,20 @@ public class CentralProcessingUnit extends Thread
 
         String drawOperation = "DRAW";
         if ((mode == MODE_EXTENDED) && (numBytes == 0)) {
-            drawExtendedSprite(xPos, yPos);
+            if (bitplane == 3) {
+                drawExtendedSprite(xPos, yPos, 1);
+                drawExtendedSprite(xPos, yPos, 2);
+            } else {
+                drawExtendedSprite(xPos, yPos, bitplane);
+            }
             drawOperation = "DRAWEX";
         } else {
-            drawNormalSprite(xPos, yPos, numBytes);
+            if (bitplane == 3) {
+                drawNormalSprite(xPos, yPos, numBytes, 1);
+                drawNormalSprite(xPos, yPos, numBytes, 2);
+            } else {
+                drawNormalSprite(xPos, yPos, numBytes, bitplane);
+            }
         }
         lastOpDesc = drawOperation + " V" + toHex(xRegister, 1) + ", V" + toHex(yRegister, 1);
     }
@@ -713,8 +723,9 @@ public class CentralProcessingUnit extends Thread
      *
      * @param xPos the x position to draw the sprite at
      * @param yPos the y position to draw the sprite at
+     * @param bitplane the bitplane to draw to
      */
-    private void drawExtendedSprite(int xPos, int yPos) {
+    private void drawExtendedSprite(int xPos, int yPos, int bitplane) {
         for (int yIndex = 0; yIndex < 16; yIndex++) {
             for (int xByte = 0; xByte < 2; xByte++) {
                 short colorByte = memory.read(index + (yIndex * 2) + xByte);
@@ -728,10 +739,10 @@ public class CentralProcessingUnit extends Thread
                     xCoord = xCoord % screen.getWidth();
 
                     boolean turnOn = (colorByte & mask) > 0;
-                    boolean currentOn = screen.getPixel(xCoord, yCoord);
+                    boolean currentOn = screen.getPixel(xCoord, yCoord, bitplane);
 
                     v[0xF] += (turnOn && currentOn) ? (short) 1 : (short) 0;
-                    screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);
+                    screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn, bitplane);
                     mask = mask >> 1;
                 }
             }
@@ -744,8 +755,9 @@ public class CentralProcessingUnit extends Thread
      * @param xPos the X position of the sprite
      * @param yPos the Y position of the sprite
      * @param numBytes the number of bytes to draw
+     * @param bitplane the bitplane to draw to
      */
-    private void drawNormalSprite(int xPos, int yPos, int numBytes) {
+    private void drawNormalSprite(int xPos, int yPos, int numBytes, int bitplane) {
         for (int yIndex = 0; yIndex < numBytes; yIndex++) {
             short colorByte = memory.read(index + yIndex);
             int yCoord = yPos + yIndex;
@@ -758,10 +770,10 @@ public class CentralProcessingUnit extends Thread
                 xCoord = xCoord % screen.getWidth();
 
                 boolean turnOn = (colorByte & mask) > 0;
-                boolean currentOn = screen.getPixel(xCoord, yCoord);
+                boolean currentOn = screen.getPixel(xCoord, yCoord, bitplane);
 
                 v[0xF] |= (turnOn && currentOn) ? (short) 1 : (short) 0;
-                screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn);
+                screen.drawPixel(xCoord, yCoord, turnOn ^ currentOn, bitplane);
                 mask = mask >> 1;
             }
         }
@@ -989,7 +1001,7 @@ public class CentralProcessingUnit extends Thread
     protected void loadPitch() {
         int x = (operand & 0x0F00) >> 8;
         pitch = v[x];
-        playbackRate = 4000 * Math.pow(2.0, ((pitch - 64) / 48));
+        playbackRate = 4000 * Math.pow(2.0, (((float) pitch - 64.0) / 48.0));
         lastOpDesc = "PITCH V" + toHex(x, 1) + " (" + v[x] + ")";
     }
 
@@ -1055,7 +1067,7 @@ public class CentralProcessingUnit extends Thread
         playbackRate = 4000.0;
         bitplane = 1;
         if (screen != null) {
-            screen.clearScreen();
+            screen.clearScreen(bitplane);
         }
     }
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -1109,7 +1109,7 @@ public class CentralProcessingUnit extends Thread
      */
     private void scrollDown(int operand) {
         int numPixels = operand & 0xF;
-        screen.scrollDown(numPixels);
+        screen.scrollDown(numPixels, bitplane);
         lastOpDesc = "Scroll Down " + numPixels;
     }
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -181,10 +181,18 @@ public class CentralProcessingUnit extends Thread
                         break;
 
                     default:
-                        if ((operand & 0xF0) == 0xC0) {
-                            scrollDown(operand);
-                        } else {
-                            lastOpDesc = "Operation " + toHex(operand, 4) + " not supported";
+                        switch (operand & 0xF0) {
+                            case 0xC0:
+                                scrollDown(operand);
+                                break;
+
+                            case 0xD0:
+                                scrollUp(operand);
+                                break;
+
+                            default:
+                                lastOpDesc = "Operation " + toHex(operand, 4) + " not supported";
+                                break;
                         }
                         break;
                 }
@@ -1103,6 +1111,7 @@ public class CentralProcessingUnit extends Thread
     }
 
     /**
+     * 00Cn - SCROLL DOWN n
      * Scrolls the screen down by the specified number of pixels.
      *
      * @param operand the operand to parse
@@ -1111,6 +1120,18 @@ public class CentralProcessingUnit extends Thread
         int numPixels = operand & 0xF;
         screen.scrollDown(numPixels, bitplane);
         lastOpDesc = "Scroll Down " + numPixels;
+    }
+
+    /**
+     * 00Dn - SCROLL UP n
+     * Scrolls the screen up by the specified number of pixels.
+     *
+     * @param operand the operand to parse
+     */
+    private void scrollUp(int operand) {
+        int numPixels = operand & 0xF;
+        screen.scrollUp(numPixels, bitplane);
+        lastOpDesc = "Scroll Up " + numPixels;
     }
 
     /**

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Screen.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Screen.java
@@ -275,9 +275,9 @@ public class Screen
         int screenWidth = maxX * modeScale * scale;
         int screenHeight = maxY * modeScale * scale;
 
+        // If bitplane 3 is selected, we can just do a fast copy instead of pixel by pixel
         if (bitplane == 3) {
             int left = -(scale * 4 * modeScale);
-
             BufferedImage bufferedImage = copyImage(backBuffer.getSubimage(0, 0, screenWidth, screenHeight));
             Graphics2D graphics = backBuffer.createGraphics();
             graphics.setColor(color0);

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -1206,7 +1206,7 @@ public class CentralProcessingUnitTest
     public void testScrollDownCalledCorrectOperands() {
         cpu.operand = 0xC8;
         cpu.executeInstruction(0x0);
-        verify(screenMock, times(1)).scrollDown(8);
+        verify(screenMock, times(1)).scrollDown(8, 1);
         assertEquals("Scroll Down 8", cpu.lastOpDesc);
     }
 

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -1137,7 +1137,9 @@ public class CentralProcessingUnitTest
             if ((subfunction != 0xE0) && (subfunction != 0xEE) &&
                     (subfunction != 0xFE) && (subfunction != 0xFF) &&
                     (subfunction != 0xFB) && (subfunction != 0xFC) &&
-                    (subfunction != 0xFD) && ((subfunction & 0xF0) != 0xC0)) {
+                    (subfunction != 0xFD) && ((subfunction & 0xF0) != 0xC0) &&
+                    ((subfunction & 0xF0) != 0xD0))
+            {
                 cpu.operand = 0x0000;
                 cpu.operand += subfunction;
                 cpu.executeInstruction(0x0);
@@ -1208,6 +1210,14 @@ public class CentralProcessingUnitTest
         cpu.executeInstruction(0x0);
         verify(screenMock, times(1)).scrollDown(8, 1);
         assertEquals("Scroll Down 8", cpu.lastOpDesc);
+    }
+
+    @Test
+    public void testScrollUpCalledCorrectOperands() {
+        cpu.operand = 0xD8;
+        cpu.executeInstruction(0x0);
+        verify(screenMock, times(1)).scrollUp(8, 1);
+        assertEquals("Scroll Up 8", cpu.lastOpDesc);
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -1150,7 +1150,7 @@ public class CentralProcessingUnitTest
     public void testScreenClearInvoked() {
         cpu.operand = 0xE0;
         cpu.executeInstruction(0x0);
-        verify(screenMock, times(2)).clearScreen();
+        verify(screenMock, times(2)).clearScreen(1);
         assertEquals("CLS", cpu.getOpShortDesc());
     }
 
@@ -1214,7 +1214,7 @@ public class CentralProcessingUnitTest
     public void testScrollLeft() {
         cpu.operand = 0xFC;
         cpu.executeInstruction(0x0);
-        verify(screenMock, times(1)).scrollLeft();
+        verify(screenMock, times(1)).scrollLeft(1);
         assertEquals("Scroll Left", cpu.lastOpDesc);
     }
 
@@ -1222,7 +1222,7 @@ public class CentralProcessingUnitTest
     public void testScrollRight() {
         cpu.operand = 0xFB;
         cpu.executeInstruction(0x0);
-        verify(screenMock, times(1)).scrollRight();
+        verify(screenMock, times(1)).scrollRight(1);
         assertEquals("Scroll Right", cpu.lastOpDesc);
     }
 
@@ -1345,14 +1345,14 @@ public class CentralProcessingUnitTest
         cpu.v[1] = 0;
         cpu.operand = 0x11;
         cpu.drawSprite();
-        assertTrue(screen.getPixel(0, 0));
-        assertFalse(screen.getPixel(1, 0));
-        assertTrue(screen.getPixel(2, 0));
-        assertFalse(screen.getPixel(3, 0));
-        assertTrue(screen.getPixel(4, 0));
-        assertFalse(screen.getPixel(5, 0));
-        assertTrue(screen.getPixel(6, 0));
-        assertFalse(screen.getPixel(7, 0));
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
         tearDownCanvas();
     }
 
@@ -1370,22 +1370,22 @@ public class CentralProcessingUnitTest
         cpu.enableExtendedMode();
         cpu.drawSprite();
         for (int byteOffset = 0; byteOffset < 16; byteOffset++) {
-            assertTrue(screen.getPixel(0, byteOffset));
-            assertFalse(screen.getPixel(1, byteOffset));
-            assertTrue(screen.getPixel(2, byteOffset));
-            assertFalse(screen.getPixel(3, byteOffset));
-            assertTrue(screen.getPixel(4, byteOffset));
-            assertFalse(screen.getPixel(5, byteOffset));
-            assertTrue(screen.getPixel(6, byteOffset));
-            assertFalse(screen.getPixel(7, byteOffset));
-            assertTrue(screen.getPixel(8, byteOffset));
-            assertFalse(screen.getPixel(9, byteOffset));
-            assertTrue(screen.getPixel(10, byteOffset));
-            assertFalse(screen.getPixel(11, byteOffset));
-            assertTrue(screen.getPixel(12, byteOffset));
-            assertFalse(screen.getPixel(13, byteOffset));
-            assertTrue(screen.getPixel(14, byteOffset));
-            assertFalse(screen.getPixel(15, byteOffset));
+            assertTrue(screen.getPixel(0, byteOffset, 1));
+            assertFalse(screen.getPixel(1, byteOffset, 1));
+            assertTrue(screen.getPixel(2, byteOffset, 1));
+            assertFalse(screen.getPixel(3, byteOffset, 1));
+            assertTrue(screen.getPixel(4, byteOffset, 1));
+            assertFalse(screen.getPixel(5, byteOffset, 1));
+            assertTrue(screen.getPixel(6, byteOffset, 1));
+            assertFalse(screen.getPixel(7, byteOffset, 1));
+            assertTrue(screen.getPixel(8, byteOffset, 1));
+            assertFalse(screen.getPixel(9, byteOffset, 1));
+            assertTrue(screen.getPixel(10, byteOffset, 1));
+            assertFalse(screen.getPixel(11, byteOffset, 1));
+            assertTrue(screen.getPixel(12, byteOffset, 1));
+            assertFalse(screen.getPixel(13, byteOffset, 1));
+            assertTrue(screen.getPixel(14, byteOffset, 1));
+            assertFalse(screen.getPixel(15, byteOffset, 1));
         }
         tearDownCanvas();
     }
@@ -1402,14 +1402,14 @@ public class CentralProcessingUnitTest
         cpu.drawSprite();
         cpu.drawSprite();
         assertEquals(1, cpu.v[0xF]);
-        assertFalse(screen.getPixel(0, 0));
-        assertFalse(screen.getPixel(1, 0));
-        assertFalse(screen.getPixel(2, 0));
-        assertFalse(screen.getPixel(3, 0));
-        assertFalse(screen.getPixel(4, 0));
-        assertFalse(screen.getPixel(5, 0));
-        assertFalse(screen.getPixel(6, 0));
-        assertFalse(screen.getPixel(7, 0));
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertFalse(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertFalse(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
         tearDownCanvas();
     }
 
@@ -1428,22 +1428,22 @@ public class CentralProcessingUnitTest
         cpu.drawSprite();
         cpu.drawSprite();
         for (int byteOffset = 0; byteOffset < 16; byteOffset++) {
-            assertFalse(screen.getPixel(0, byteOffset));
-            assertFalse(screen.getPixel(1, byteOffset));
-            assertFalse(screen.getPixel(2, byteOffset));
-            assertFalse(screen.getPixel(3, byteOffset));
-            assertFalse(screen.getPixel(4, byteOffset));
-            assertFalse(screen.getPixel(5, byteOffset));
-            assertFalse(screen.getPixel(6, byteOffset));
-            assertFalse(screen.getPixel(7, byteOffset));
-            assertFalse(screen.getPixel(8, byteOffset));
-            assertFalse(screen.getPixel(9, byteOffset));
-            assertFalse(screen.getPixel(10, byteOffset));
-            assertFalse(screen.getPixel(11, byteOffset));
-            assertFalse(screen.getPixel(12, byteOffset));
-            assertFalse(screen.getPixel(13, byteOffset));
-            assertFalse(screen.getPixel(14, byteOffset));
-            assertFalse(screen.getPixel(15, byteOffset));
+            assertFalse(screen.getPixel(0, byteOffset, 1));
+            assertFalse(screen.getPixel(1, byteOffset, 1));
+            assertFalse(screen.getPixel(2, byteOffset, 1));
+            assertFalse(screen.getPixel(3, byteOffset, 1));
+            assertFalse(screen.getPixel(4, byteOffset, 1));
+            assertFalse(screen.getPixel(5, byteOffset, 1));
+            assertFalse(screen.getPixel(6, byteOffset, 1));
+            assertFalse(screen.getPixel(7, byteOffset, 1));
+            assertFalse(screen.getPixel(8, byteOffset, 1));
+            assertFalse(screen.getPixel(9, byteOffset, 1));
+            assertFalse(screen.getPixel(10, byteOffset, 1));
+            assertFalse(screen.getPixel(11, byteOffset, 1));
+            assertFalse(screen.getPixel(12, byteOffset, 1));
+            assertFalse(screen.getPixel(13, byteOffset, 1));
+            assertFalse(screen.getPixel(14, byteOffset, 1));
+            assertFalse(screen.getPixel(15, byteOffset, 1));
         }
         tearDownCanvas();
     }
@@ -1461,14 +1461,14 @@ public class CentralProcessingUnitTest
         memory.write(0x00, 0x200);
         cpu.drawSprite();
         assertEquals(0, cpu.v[0xF]);
-        assertTrue(screen.getPixel(0, 0));
-        assertTrue(screen.getPixel(1, 0));
-        assertTrue(screen.getPixel(2, 0));
-        assertTrue(screen.getPixel(3, 0));
-        assertTrue(screen.getPixel(4, 0));
-        assertTrue(screen.getPixel(5, 0));
-        assertTrue(screen.getPixel(6, 0));
-        assertTrue(screen.getPixel(7, 0));
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertTrue(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertTrue(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertTrue(screen.getPixel(7, 0, 1));
         tearDownCanvas();
     }
 }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
@@ -62,38 +62,151 @@ public class ScreenTest
 
     @Test
     public void testScreenTurningPixelsOnSetsGetPixel() {
-        for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
-            for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true, 1);
-                assertTrue(screen.getPixel(xCoord, yCoord, 1));
+        for (int x = 0; x < screen.getWidth(); x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                screen.drawPixel(x, y, true, 1);
+                assertTrue(screen.getPixel(x, y, 1));
+            }
+        }
+    }
+
+    @Test
+    public void testGetPixelOnBitplane0ReturnsFalse() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                screen.drawPixel(x, y, true, 2);
+                assertFalse(screen.getPixel(x, y, 0));
+            }
+        }
+    }
+
+    @Test
+    public void testDrawPixelOnBitplane0DoesNothing() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 0);
+                assertFalse(screen.getPixel(x, y, 1));
+                assertFalse(screen.getPixel(x, y, 2));
             }
         }
     }
 
     @Test
     public void testScreenTurningPixelsOffSetsPixelOff() {
-        for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
-            for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true, 1);
-                assertTrue(screen.getPixel(xCoord, yCoord, 1));
-                screen.drawPixel(xCoord, yCoord, false, 1);
-                assertFalse(screen.getPixel(xCoord, yCoord, 1));
+        for (int x = 0; x < screen.getWidth(); x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                screen.drawPixel(x, y, true, 1);
+                assertTrue(screen.getPixel(x, y, 1));
+                screen.drawPixel(x, y, false, 1);
+                assertFalse(screen.getPixel(x, y, 1));
             }
         }
     }
 
     @Test
-    public void testClearScreenSetsAllPixelsOff() {
-        for (int xCoord = 0; xCoord < 64; xCoord++) {
-            for (int yCoord = 0; yCoord < 32; yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true, 1);
-                assertTrue(screen.getPixel(xCoord, yCoord, 1));
+    public void testWritePixelTurnsOnPixelOnBitplane1Only() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                assertTrue(screen.getPixel(x, y, 1));
+                assertFalse(screen.getPixel(x, y, 2));
+            }
+        }
+    }
+
+    @Test
+    public void testWritePixelTurnsOnPixelOnBitplane2Only() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 2);
+                assertTrue(screen.getPixel(x, y, 2));
+                assertFalse(screen.getPixel(x, y, 1));
+            }
+        }
+    }
+
+    @Test
+    public void testWritePixelOnBitplane3TurnsOnPixelOnBitplane1And2() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 3);
+                assertTrue(screen.getPixel(x, y, 2));
+                assertTrue(screen.getPixel(x, y, 1));
+            }
+        }
+    }
+
+    @Test
+    public void testClearScreenOnBitplane0DoesNothingToBitplane1And2() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                screen.drawPixel(x, y, true, 2);
+                assertTrue(screen.getPixel(x, y, 1));
+                assertTrue(screen.getPixel(x, y, 2));
+            }
+        }
+        screen.clearScreen(0);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                assertTrue(screen.getPixel(x, y, 1));
+                assertTrue(screen.getPixel(x, y, 2));
+            }
+        }
+    }
+
+    @Test
+    public void testClearScreenSetsAllPixelsOffOnBitplane1() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                assertTrue(screen.getPixel(x, y, 1));
+                assertFalse(screen.getPixel(x, y, 2));
             }
         }
         screen.clearScreen(1);
-        for (int xCoord = 0; xCoord < 64; xCoord++) {
-            for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                assertFalse(screen.getPixel(xCoord, yCoord, 1));
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                assertFalse(screen.getPixel(x, y, 1));
+            }
+        }
+    }
+
+    @Test
+    public void testClearScreenSetsAllPixelsOffOnBitplane1OnlyWhenBothSet() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                screen.drawPixel(x, y, true, 2);
+                assertTrue(screen.getPixel(x, y, 1));
+                assertTrue(screen.getPixel(x, y, 2));
+            }
+        }
+        screen.clearScreen(1);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                assertFalse(screen.getPixel(x, y, 1));
+                assertTrue(screen.getPixel(x, y, 2));
+            }
+        }
+    }
+
+    @Test
+    public void testClearScreenSetsAllPixelsOffOnBitplane3WhenBothSet() {
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 32; y++) {
+                screen.drawPixel(x, y, true, 1);
+                screen.drawPixel(x, y, true, 2);
+                assertTrue(screen.getPixel(x, y, 1));
+                assertTrue(screen.getPixel(x, y, 2));
+            }
+        }
+        screen.clearScreen(3);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < screen.getHeight(); y++) {
+                assertFalse(screen.getPixel(x, y, 1));
+                assertFalse(screen.getPixel(x, y, 2));
             }
         }
     }
@@ -111,12 +224,59 @@ public class ScreenTest
     }
 
     @Test
-    public void testScrollRight() throws IOException {
+    public void testScrollRightOnBitplane0DoesNothing() throws IOException {
         screen = new Screen(2);
         screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        screen.scrollRight(0);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertFalse(screen.getPixel(4, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+    }
+
+    @Test
+    public void testScrollRightBitplane1Only() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
         screen.scrollRight(1);
-        assertTrue(screen.getPixel(4, 0, 1));
         assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+    }
+
+    @Test
+    public void testScrollRightBitplane3() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
+        screen.scrollRight(3);
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertTrue(screen.getPixel(4, 0, 2));
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
@@ -409,6 +409,48 @@ public class ScreenTest
     }
 
     @Test
+    public void testScrollUpBitplane0DoesNothing() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 1, true, 1);
+        screen.drawPixel(0, 1, true, 2);
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
+        screen.scrollUp(1, 0);
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
+    }
+
+    @Test
+    public void testScrollUpBitplane1() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 1, true, 1);
+        screen.drawPixel(0, 1, true, 2);
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
+        screen.scrollUp(1, 1);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
+    }
+
+    @Test
+    public void testScrollUpBitplane3BothPixelsActive() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 1, true, 1);
+        screen.drawPixel(0, 1, true, 2);
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
+        screen.scrollUp(1, 3);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(0, 1, 1));
+        assertFalse(screen.getPixel(0, 1, 2));
+    }
+
+    @Test
     public void testGetBackBufferWorksCorrectly() {
         screen = new Screen(2);
         assertEquals(screen.backBuffer, screen.getBuffer());

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
@@ -55,7 +55,7 @@ public class ScreenTest
     public void testScreenNoPixelsOnAtInit() {
         for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                assertFalse(screen.getPixel(xCoord, yCoord));
+                assertFalse(screen.getPixel(xCoord, yCoord, 1));
             }
         }
     }
@@ -64,8 +64,8 @@ public class ScreenTest
     public void testScreenTurningPixelsOnSetsGetPixel() {
         for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true);
-                assertTrue(screen.getPixel(xCoord, yCoord));
+                screen.drawPixel(xCoord, yCoord, true, 1);
+                assertTrue(screen.getPixel(xCoord, yCoord, 1));
             }
         }
     }
@@ -74,9 +74,10 @@ public class ScreenTest
     public void testScreenTurningPixelsOffSetsPixelOff() {
         for (int xCoord = 0; xCoord < screen.getWidth(); xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true);
-                screen.drawPixel(xCoord, yCoord, false);
-                assertFalse(screen.getPixel(xCoord, yCoord));
+                screen.drawPixel(xCoord, yCoord, true, 1);
+                assertTrue(screen.getPixel(xCoord, yCoord, 1));
+                screen.drawPixel(xCoord, yCoord, false, 1);
+                assertFalse(screen.getPixel(xCoord, yCoord, 1));
             }
         }
     }
@@ -85,13 +86,14 @@ public class ScreenTest
     public void testClearScreenSetsAllPixelsOff() {
         for (int xCoord = 0; xCoord < 64; xCoord++) {
             for (int yCoord = 0; yCoord < 32; yCoord++) {
-                screen.drawPixel(xCoord, yCoord, true);
+                screen.drawPixel(xCoord, yCoord, true, 1);
+                assertTrue(screen.getPixel(xCoord, yCoord, 1));
             }
         }
-        screen.clearScreen();
+        screen.clearScreen(1);
         for (int xCoord = 0; xCoord < 64; xCoord++) {
             for (int yCoord = 0; yCoord < screen.getHeight(); yCoord++) {
-                assertFalse(screen.getPixel(xCoord, yCoord));
+                assertFalse(screen.getPixel(xCoord, yCoord, 1));
             }
         }
     }
@@ -111,28 +113,28 @@ public class ScreenTest
     @Test
     public void testScrollRight() throws IOException {
         screen = new Screen(2);
-        screen.drawPixel(0, 0, true);
-        screen.scrollRight();
-        assertTrue(screen.getPixel(4,0));
-        assertFalse(screen.getPixel(0,0));
+        screen.drawPixel(0, 0, true, 1);
+        screen.scrollRight(1);
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 1));
     }
 
     @Test
     public void testScrollLeft() throws IOException {
         screen = new Screen(2);
-        screen.drawPixel(4, 0, true);
-        screen.scrollLeft();
-        assertTrue(screen.getPixel(0, 0));
-        assertFalse(screen.getPixel(4, 0));
+        screen.drawPixel(4, 0, true, 1);
+        screen.scrollLeft(1);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(4, 0, 1));
     }
 
     @Test
     public void testScrollDown() throws IOException {
         screen = new Screen(2);
-        screen.drawPixel(0, 0, true);
+        screen.drawPixel(0, 0, true, 1);
         screen.scrollDown(4);
-        assertTrue(screen.getPixel(0, 4));
-        assertFalse(screen.getPixel(0, 0));
+        assertTrue(screen.getPixel(0, 4, 1));
+        assertFalse(screen.getPixel(0, 0, 1));
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/ScreenTest.java
@@ -289,12 +289,123 @@ public class ScreenTest
     }
 
     @Test
+    public void testScrollLeftOnBitplane0DoesNothing() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(63, 0, true, 1);
+        screen.drawPixel(63, 0, true, 2);
+        assertTrue(screen.getPixel(63, 0, 1));
+        assertTrue(screen.getPixel(63, 0, 2));
+        screen.scrollLeft(0);
+        assertTrue(screen.getPixel(63, 0, 1));
+        assertFalse(screen.getPixel(62, 0, 1));
+        assertFalse(screen.getPixel(61, 0, 1));
+        assertFalse(screen.getPixel(60, 0, 1));
+        assertFalse(screen.getPixel(59, 0, 1));
+        assertTrue(screen.getPixel(63, 0, 2));
+        assertFalse(screen.getPixel(62, 0, 2));
+        assertFalse(screen.getPixel(61, 0, 2));
+        assertFalse(screen.getPixel(60, 0, 2));
+        assertFalse(screen.getPixel(59, 0, 2));
+    }
+
+    @Test
+    public void testScrollLeftBitplane1Only() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(63, 0, true, 1);
+        screen.drawPixel(63, 0, true, 2);
+        assertTrue(screen.getPixel(63, 0, 1));
+        assertTrue(screen.getPixel(63, 0, 2));
+        screen.scrollLeft(1);
+        assertFalse(screen.getPixel(63, 0, 1));
+        assertFalse(screen.getPixel(62, 0, 1));
+        assertFalse(screen.getPixel(61, 0, 1));
+        assertFalse(screen.getPixel(60, 0, 1));
+        assertTrue(screen.getPixel(59, 0, 1));
+        assertTrue(screen.getPixel(63, 0, 2));
+        assertFalse(screen.getPixel(62, 0, 2));
+        assertFalse(screen.getPixel(61, 0, 2));
+        assertFalse(screen.getPixel(60, 0, 2));
+        assertFalse(screen.getPixel(59, 0, 2));
+    }
+
+    @Test
+    public void testScrollLeftBitplane3() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(63, 0, true, 1);
+        screen.drawPixel(63, 0, true, 2);
+        assertTrue(screen.getPixel(63, 0, 1));
+        assertTrue(screen.getPixel(63, 0, 2));
+        screen.scrollLeft(3);
+        assertFalse(screen.getPixel(63, 0, 1));
+        assertFalse(screen.getPixel(62, 0, 1));
+        assertFalse(screen.getPixel(61, 0, 1));
+        assertFalse(screen.getPixel(60, 0, 1));
+        assertTrue(screen.getPixel(59, 0, 1));
+        assertFalse(screen.getPixel(63, 0, 2));
+        assertFalse(screen.getPixel(62, 0, 2));
+        assertFalse(screen.getPixel(61, 0, 2));
+        assertFalse(screen.getPixel(60, 0, 2));
+        assertTrue(screen.getPixel(59, 0, 2));
+    }
+
+    @Test
     public void testScrollDown() throws IOException {
         screen = new Screen(2);
         screen.drawPixel(0, 0, true, 1);
-        screen.scrollDown(4);
+        screen.scrollDown(4, 1);
         assertTrue(screen.getPixel(0, 4, 1));
         assertFalse(screen.getPixel(0, 0, 1));
+    }
+
+    @Test
+    public void testScrollDownBitplane0DoesNothing() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
+        screen.scrollDown(4, 0);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+    }
+
+    @Test
+    public void testScrollDownBitplane1() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        screen.scrollDown(1, 1);
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertFalse(screen.getPixel(0, 1, 2));
+    }
+
+    @Test
+    public void testScrollDownBitplane1BothPixelsActive() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        screen.scrollDown(1, 1);
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertFalse(screen.getPixel(0, 1, 2));
+    }
+
+    @Test
+    public void testScrollDownBitplane3BothPixelsActive() throws IOException {
+        screen = new Screen(2);
+        screen.drawPixel(0, 0, true, 1);
+        screen.drawPixel(0, 0, true, 2);
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertTrue(screen.getPixel(0, 0, 2));
+        screen.scrollDown(1, 3);
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(0, 1, 1));
+        assertTrue(screen.getPixel(0, 1, 2));
     }
 
     @Test


### PR DESCRIPTION
This PR adds the ability to draw pixels on different bitplanes. The clear, scroll, and draw instructions are updated to draw to different bitplanes. The scroll up operation was added. Clear routines were updated to clear only on the specified bitplane. Unit and integration tests added to catch new conditions. Additionally:

- This PR closes #27 
- This PR closes #31 