### PR TITLE
XO Bugfixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,112 @@ with links to public domain repositories where applicable.
 
 ### Chip 8 ROMs
 
-| ROM Name                                                              |      Working       |     Flags     | 
-|:----------------------------------------------------------------------|:------------------:|:-------------:|
-| [down8](https://johnearnest.github.io/chip8Archive/play.html?p=down8) | :heavy_check_mark: |               | 
+| ROM Name                                                                                          |      Working       |     Flags     | 
+|:--------------------------------------------------------------------------------------------------|:------------------:|:-------------:|
+| [1D Cellular Automata](https://johnearnest.github.io/chip8Archive/play.html?p=1dcell)             | :heavy_check_mark: |               |
+| [8CE Attourny - Disc 1](https://johnearnest.github.io/chip8Archive/play.html?p=8ceattourny_d1)    | :heavy_check_mark: |               |
+| [8CE Attourny - Disc 2](https://johnearnest.github.io/chip8Archive/play.html?p=8ceattourny_d2)    |     :question:     |               |
+| [8CE Attourny - Disc 3](https://johnearnest.github.io/chip8Archive/play.html?p=8ceattourny_d3)    |     :question:     |               |
+| [Bad Kaiju Ju](https://johnearnest.github.io/chip8Archive/play.html?p=BadKaiJuJu)                 | :heavy_check_mark: |               |
+| [Br8kout](https://johnearnest.github.io/chip8Archive/play.html?p=br8kout)                         | :heavy_check_mark: |               |
+| [Carbon8](https://johnearnest.github.io/chip8Archive/play.html?p=carbon8)                         | :heavy_check_mark: |               |
+| [Cave Explorer](https://johnearnest.github.io/chip8Archive/play.html?p=caveexplorer)              | :heavy_check_mark: |               |
+| [Chipquarium](https://johnearnest.github.io/chip8Archive/play.html?p=chipquarium)                 | :heavy_check_mark: |               |
+| [Danm8ku](https://johnearnest.github.io/chip8Archive/play.html?p=danm8ku)                         |        :x:         |               |
+| [down8](https://johnearnest.github.io/chip8Archive/play.html?p=down8)                             | :heavy_check_mark: |               |
+| [Falling Ghosts](https://veganjay.itch.io/falling-ghosts)                                         |     :question:     |               |
+| [Flight Runner](https://johnearnest.github.io/chip8Archive/play.html?p=flightrunner)              |     :question:     |               |
+| [Fuse](https://johnearnest.github.io/chip8Archive/play.html?p=fuse)                               |     :question:     |               |
+| [Ghost Escape](https://johnearnest.github.io/chip8Archive/play.html?p=ghostEscape)                |     :question:     |               | 
+| [Glitch Ghost](https://johnearnest.github.io/chip8Archive/play.html?p=glitchGhost)                |     :question:     |               |
+| [Horse World Online](https://johnearnest.github.io/chip8Archive/play.html?p=horseWorldOnline)     |     :question:     |               |
+| [Invisible Man](https://mremerson.itch.io/invisible-man)                                          |     :question:     | `clip_quirks` |
+| [Knumber Knower](https://internet-janitor.itch.io/knumber-knower)                                 |     :question:     |               | 
+| [Masquer8](https://johnearnest.github.io/chip8Archive/play.html?p=masquer8)                       |     :question:     |               |
+| [Mastermind](https://johnearnest.github.io/chip8Archive/play.html?p=mastermind)                   |     :question:     |               |
+| [Mini Lights Out](https://johnearnest.github.io/chip8Archive/play.html?p=mini-lights-out)         |     :question:     |               |
+| [Octo: a Chip 8 Story](https://johnearnest.github.io/chip8Archive/play.html?p=octoachip8story)    |     :question:     |               |
+| [Octogon Trail](https://tarsi.itch.io/octogon-trail)                                              |     :question:     |               |
+| [Octojam 1 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam1title)           |     :question:     |               |
+| [Octojam 2 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam2title)           |     :question:     |               |
+| [Octojam 3 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam3title)           |     :question:     |               |
+| [Octojam 4 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam4title)           |     :question:     |               |
+| [Octojam 5 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam5title)           |     :question:     |               |
+| [Octojam 6 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam6title)           |     :question:     |               |
+| [Octojam 7 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam7title)           |     :question:     |               |
+| [Octojam 8 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam8title)           |     :question:     |               |
+| [Octojam 9 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam9title)           |     :question:     |               |
+| [Octojam 10 Title](https://johnearnest.github.io/chip8Archive/play.html?p=octojam10title)         |     :question:     |               |
+| [Octo Rancher](https://johnearnest.github.io/chip8Archive/play.html?p=octorancher)                |     :question:     |               |
+| [Outlaw](https://johnearnest.github.io/chip8Archive/play.html?p=outlaw)                           |     :question:     |               |
+| [Pet Dog](https://johnearnest.github.io/chip8Archive/play.html?p=petdog)                          |     :question:     |               | 
+| [Piper](https://johnearnest.github.io/chip8Archive/play.html?p=piper)                             |     :question:     |               | 
+| [Pumpkin "Dress" Up](https://johnearnest.github.io/chip8Archive/play.html?p=pumpkindressup)       |     :question:     |               |
+| [RPS](https://johnearnest.github.io/chip8Archive/play.html?p=RPS)                                 |     :question:     |               |
+| [Slippery Slope](https://johnearnest.github.io/chip8Archive/play.html?p=slipperyslope)            |     :question:     |               |
+| [Snek](https://johnearnest.github.io/chip8Archive/play.html?p=snek)                               |     :question:     |               |
+| [Space Jam](https://johnearnest.github.io/chip8Archive/play.html?p=spacejam)                      |     :question:     |               |
+| [Spock Paper Scissors](https://johnearnest.github.io/chip8Archive/play.html?p=spockpaperscissors) |     :question:     |               |
+| [Super Pong](https://johnearnest.github.io/chip8Archive/play.html?p=superpong)                    |     :question:     |               |
+| [Tank!](https://johnearnest.github.io/chip8Archive/play.html?p=tank)                              |     :question:     |               |
+| [TOMB STON TIPP](https://johnearnest.github.io/chip8Archive/play.html?p=tombstontipp)             |     :question:     |               |
+| [WDL](https://johnearnest.github.io/chip8Archive/play.html?p=wdl)                                 |     :question:     |               |
+
+### Super Chip ROMs
+
+| ROM Name                                                                                     |   Working   | Flags | 
+|:---------------------------------------------------------------------------------------------|:-----------:|:-----:|
+| [Applejak](https://johnearnest.github.io/chip8Archive/play.html?p=applejak)                  | :question:  |       |
+| [Bulb](https://johnearnest.github.io/chip8Archive/play.html?p=bulb)                          | :question:  |       |
+| [Black Rainbow](https://johnearnest.github.io/chip8Archive/play.html?p=blackrainbow)         | :question:  |       |
+| [Chipcross](https://tobiasvl.itch.io/chipcross)                                              | :question:  |       |
+| [Chipolarium](https://tobiasvl.itch.io/chipolarium)                                          | :question:  |       |
+| [Collision Course](https://ninjaweedle.itch.io/collision-course)                             | :question:  |       |
+| [Dodge](https://johnearnest.github.io/chip8Archive/play.html?p=dodge)                        | :question:  |       |
+| [DVN8](https://johnearnest.github.io/chip8Archive/play.html?p=DVN8)                          | :question:  |       |
+| [Eaty the Alien](https://johnearnest.github.io/chip8Archive/play.html?p=eaty)                | :question:  |       |
+| [Grad School Simulator 2014](https://johnearnest.github.io/chip8Archive/play.html?p=gradsim) | :question:  |       |
+| [Horsey Jump](https://johnearnest.github.io/chip8Archive/play.html?p=horseyJump)             | :question:  |       |
+| [Knight](https://johnearnest.github.io/chip8Archive/play.html?p=knight)                      |     :x:     |       |
+| [Mondri8](https://johnearnest.github.io/chip8Archive/play.html?p=mondri8)                    | :question:  |       |
+| [Octopeg](https://johnearnest.github.io/chip8Archive/play.html?p=octopeg)                    | :question:  |       |
+| [Octovore](https://johnearnest.github.io/chip8Archive/play.html?p=octovore)                  | :question:  |       |
+| [Rocto](https://johnearnest.github.io/chip8Archive/play.html?p=rockto)                       | :question:  |       |
+| [Sens8tion](https://johnearnest.github.io/chip8Archive/play.html?p=sens8tion)                | :question:  |       |
+| [Snake](https://johnearnest.github.io/chip8Archive/play.html?p=snake)                        | :question:  |       |
+| [Squad](https://johnearnest.github.io/chip8Archive/play.html?p=squad)                        | :question:  |       |
+| [Sub-Terr8nia](https://johnearnest.github.io/chip8Archive/play.html?p=sub8)                  | :question:  |       |
+| [Super Octogon](https://johnearnest.github.io/chip8Archive/play.html?p=octogon)              | :question:  |       |
+| [Super Square](https://johnearnest.github.io/chip8Archive/play.html?p=supersquare)           | :question:  |       |
+| [The Binding of COSMAC](https://johnearnest.github.io/chip8Archive/play.html?p=binding)      | :question:  |       |
+| [Turnover '77](https://johnearnest.github.io/chip8Archive/play.html?p=turnover77)            | :question:  |       |
+
+### XO Chip ROMs
+
+| ROM Name                                                                                              |   Working   | Flags | 
+|:------------------------------------------------------------------------------------------------------|:-----------:|:-----:|
+| [An Evening to Die For](https://johnearnest.github.io/chip8Archive/play.html?p=anEveningToDieFor)     | :question:  |       |
+| [Business Is Contagious](https://johnearnest.github.io/chip8Archive/play.html?p=businessiscontagious) | :question:  |       |
+| [Chicken Scratch](https://johnearnest.github.io/chip8Archive/play.html?p=chickenScratch)              | :question:  |       |
+| [Civiliz8n](https://johnearnest.github.io/chip8Archive/play.html?p=civiliz8n)                         | :question:  |       |
+| [Flutter By](https://johnearnest.github.io/chip8Archive/play.html?p=flutterby)                        | :question:  |       |
+| [Into The Garlicscape](https://johnearnest.github.io/chip8Archive/play.html?p=garlicscape)            | :question:  |       |
+| [jub8 Song 1](https://johnearnest.github.io/chip8Archive/play.html?p=jub8-1)                          | :question:  |       |
+| [jub8 Song 2](https://johnearnest.github.io/chip8Archive/play.html?p=jub8-2)                          | :question:  |       |
+| [Kesha Was Biird](https://johnearnest.github.io/chip8Archive/play.html?p=keshaWasBiird)               | :question:  |       |
+| [Kesha Was Niinja](https://johnearnest.github.io/chip8Archive/play.html?p=keshaWasNiinja)             | :question:  |       |
+| [Octo paint](https://johnearnest.github.io/chip8Archive/play.html?p=octopaint)                        | :question:  |       |
+| [Octo Party Mix!](https://johnearnest.github.io/chip8Archive/play.html?p=OctoPartyMix)                | :question:  |       |
+| [Octoma](https://johnearnest.github.io/chip8Archive/play.html?p=octoma)                               | :question:  |       |
+| [Red October V](https://johnearnest.github.io/chip8Archive/play.html?p=redOctober)                    | :question:  |       |
+| [Skyward](https://johnearnest.github.io/chip8Archive/play.html?p=skyward)                             | :question:  |       |
+| [Spock Paper Scissors](https://johnearnest.github.io/chip8Archive/play.html?p=spockpaperscissors)     | :question:  |       |
+| [T8NKS](https://johnearnest.github.io/chip8Archive/play.html?p=t8nks)                                 | :question:  |       |
+| [Tapeworm](https://tarsi.itch.io/tapeworm)                                                            | :question:  |       |
+| [Truck Simul8or](https://johnearnest.github.io/chip8Archive/play.html?p=trucksimul8or)                | :question:  |       |
+| [SK8 H8 1988](https://johnearnest.github.io/chip8Archive/play.html?p=sk8)                             | :question:  |       |
+| [Super NeatBoy](https://johnearnest.github.io/chip8Archive/play.html?p=superneatboy)                  | :question:  |       |
+| [Wonky Pong](https://johnearnest.github.io/chip8Archive/play.html?p=wonkypong)                        | :question:  |       |
 
 ## Third Party Licenses and Attributions
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
@@ -178,12 +178,20 @@ public class Emulator
 
         while (state != EmulatorState.KILLED) {
             if (state != EmulatorState.PAUSED) {
-                cpu.fetchIncrementExecute();
-                try {
-                    Thread.sleep(cpuCycleTime);
-                } catch (InterruptedException e) {
-                    LOGGER.warning("CPU sleep interrupted");
+                if (!cpu.isAwaitingKeypress()) {
+                    cpu.fetchIncrementExecute();
+                    try {
+                        Thread.sleep(cpuCycleTime);
+                    } catch (InterruptedException e) {
+                        LOGGER.warning("CPU sleep interrupted");
+                    }
+                } else {
+                    cpu.decodeKeypressAndContinue();
                 }
+            }
+
+            if (keyboard.getRawKeyPressed() == Keyboard.CHIP8_QUIT) {
+                break;
             }
         }
         kill();

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/EmulatorState.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/EmulatorState.java
@@ -6,5 +6,5 @@ package ca.craigthomas.chip8java.emulator.components;
 
 public enum EmulatorState
 {
-    PAUSED, RUNNING, KILLED
+    PAUSED, RUNNING, KILLED, WAIT_FOR_KEYPRESS
 }

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/EmulatorState.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/EmulatorState.java
@@ -6,5 +6,5 @@ package ca.craigthomas.chip8java.emulator.components;
 
 public enum EmulatorState
 {
-    PAUSED, RUNNING, KILLED, WAIT_FOR_KEYPRESS
+    PAUSED, RUNNING, KILLED
 }

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Keyboard.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Keyboard.java
@@ -36,39 +36,18 @@ public class Keyboard extends KeyAdapter
     // The current key being pressed, -1 if no key
     protected int currentKeyPressed = -1;
 
-    // Stores the last debug key keypress
-    protected int debugKeyPressed;
+    // Stores the last raw key keypress
+    protected int rawKeyPressed;
 
     // The key to quit the emulator
     protected static final int CHIP8_QUIT = KeyEvent.VK_ESCAPE;
 
-    // The key to enter debug mode
-    public static final int CHIP8_STEP = KeyEvent.VK_P;
-
-    // The key to enter trace mode
-    public static final int CHIP8_TRACE = KeyEvent.VK_O;
-
-    // The key to stop trace or debug
-    public static final int CHIP8_NORMAL = KeyEvent.VK_L;
-
-    // The key to advance to the next instruction
-    public static final int CHIP8_NEXT = KeyEvent.VK_N;
-
-    private Emulator emulator;
-
-    public Keyboard(Emulator emulator) {
-        this.emulator = emulator;
-    }
+    public Keyboard(Emulator emulator) {}
 
     @Override
     public void keyPressed(KeyEvent e) {
-        debugKeyPressed = e.getKeyCode();
-
-        if (debugKeyPressed == CHIP8_QUIT) {
-            emulator.kill();
-        }
-
-        currentKeyPressed = mapKeycodeToChip8Key(debugKeyPressed);
+        rawKeyPressed = e.getKeyCode();
+        currentKeyPressed = mapKeycodeToChip8Key(rawKeyPressed);
     }
 
     @Override
@@ -109,9 +88,7 @@ public class Keyboard extends KeyAdapter
      *
      * @return the value of the currently pressed debug key.
      */
-    public int getDebugKey() {
-        int debugKey = debugKeyPressed;
-        debugKeyPressed = 0;
-        return debugKey;
+    public int getRawKeyPressed() {
+        return rawKeyPressed;
     }
 }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -4,6 +4,7 @@
  */
 package ca.craigthomas.chip8java.emulator.components;
 
+import static ca.craigthomas.chip8java.emulator.components.CentralProcessingUnit.MODE_EXTENDED;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -1157,6 +1158,357 @@ public class CentralProcessingUnitTest
     }
 
     @Test
+    public void testDrawSpriteNormalBitplane1IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x01, 0x0201);
+        memory.write(0xAA, 0x5000);
+        cpu.index = 0x5000;
+        cpu.bitplane = 1;
+        cpu.fetchIncrementExecute();
+
+        // First bitplane pattern
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+
+        // Second bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+        assertFalse(screen.getPixel(5, 0, 2));
+        assertFalse(screen.getPixel(6, 0, 2));
+        assertFalse(screen.getPixel(7, 0, 2));
+    }
+
+    @Test
+    public void testDrawSpriteExtendedBitplane1IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+        cpu.enableExtendedMode();
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x00, 0x0201);
+        memory.write(0xAA, 0x5000);
+        memory.write(0x55, 0x5001);
+        memory.write(0xAA, 0x5002);
+        memory.write(0x55, 0x5003);
+        memory.write(0xAA, 0x5004);
+        memory.write(0x55, 0x5005);
+        memory.write(0xAA, 0x5006);
+        memory.write(0x55, 0x5007);
+        memory.write(0xAA, 0x5008);
+        memory.write(0x55, 0x5009);
+        memory.write(0xAA, 0x500A);
+        memory.write(0x55, 0x500B);
+        memory.write(0xAA, 0x500C);
+        memory.write(0x55, 0x500D);
+        memory.write(0xAA, 0x500E);
+        memory.write(0x55, 0x500F);
+
+        cpu.index = 0x5000;
+        cpu.bitplane = 1;
+        cpu.fetchIncrementExecute();
+
+        // First bitplane pattern
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+        assertFalse(screen.getPixel(8, 0, 1));
+        assertTrue(screen.getPixel(9, 0, 1));
+        assertFalse(screen.getPixel(10, 0, 1));
+        assertTrue(screen.getPixel(11, 0, 1));
+        assertFalse(screen.getPixel(12, 0, 1));
+        assertTrue(screen.getPixel(13, 0, 1));
+        assertFalse(screen.getPixel(14, 0, 1));
+        assertTrue(screen.getPixel(15, 0, 1));
+
+        // Second bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+        assertFalse(screen.getPixel(5, 0, 2));
+        assertFalse(screen.getPixel(6, 0, 2));
+        assertFalse(screen.getPixel(7, 0, 2));
+        assertFalse(screen.getPixel(8, 0, 2));
+        assertFalse(screen.getPixel(9, 0, 2));
+        assertFalse(screen.getPixel(10, 0, 2));
+        assertFalse(screen.getPixel(11, 0, 2));
+        assertFalse(screen.getPixel(12, 0, 2));
+        assertFalse(screen.getPixel(13, 0, 2));
+        assertFalse(screen.getPixel(14, 0, 2));
+        assertFalse(screen.getPixel(15, 0, 2));
+    }
+
+    @Test
+    public void testDrawSpriteNormalBitplane2IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x01, 0x0201);
+        memory.write(0x55, 0x5000);
+        cpu.index = 0x5000;
+        cpu.bitplane = 2;
+        cpu.fetchIncrementExecute();
+
+        // First bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertFalse(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertFalse(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+
+        // Second bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertTrue(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+        assertTrue(screen.getPixel(5, 0, 2));
+        assertFalse(screen.getPixel(6, 0, 2));
+        assertTrue(screen.getPixel(7, 0, 2));
+    }
+
+    @Test
+    public void testDrawSpriteExtendedBitplane2IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+        cpu.enableExtendedMode();
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x00, 0x0201);
+        memory.write(0xAA, 0x5000);
+        memory.write(0x55, 0x5001);
+        memory.write(0xAA, 0x5002);
+        memory.write(0x55, 0x5003);
+        memory.write(0xAA, 0x5004);
+        memory.write(0x55, 0x5005);
+        memory.write(0xAA, 0x5006);
+        memory.write(0x55, 0x5007);
+        memory.write(0xAA, 0x5008);
+        memory.write(0x55, 0x5009);
+        memory.write(0xAA, 0x500A);
+        memory.write(0x55, 0x500B);
+        memory.write(0xAA, 0x500C);
+        memory.write(0x55, 0x500D);
+        memory.write(0xAA, 0x500E);
+        memory.write(0x55, 0x500F);
+
+        cpu.index = 0x5000;
+        cpu.bitplane = 2;
+        cpu.fetchIncrementExecute();
+
+        // Second bitplane pattern
+        assertTrue(screen.getPixel(0, 0, 2));
+        assertFalse(screen.getPixel(1, 0, 2));
+        assertTrue(screen.getPixel(2, 0, 2));
+        assertFalse(screen.getPixel(3, 0, 2));
+        assertTrue(screen.getPixel(4, 0, 2));
+        assertFalse(screen.getPixel(5, 0, 2));
+        assertTrue(screen.getPixel(6, 0, 2));
+        assertFalse(screen.getPixel(7, 0, 2));
+        assertFalse(screen.getPixel(8, 0, 2));
+        assertTrue(screen.getPixel(9, 0, 2));
+        assertFalse(screen.getPixel(10, 0, 2));
+        assertTrue(screen.getPixel(11, 0, 2));
+        assertFalse(screen.getPixel(12, 0, 2));
+        assertTrue(screen.getPixel(13, 0, 2));
+        assertFalse(screen.getPixel(14, 0, 2));
+        assertTrue(screen.getPixel(15, 0, 2));
+
+        // First bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertFalse(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertFalse(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertFalse(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+        assertFalse(screen.getPixel(8, 0, 1));
+        assertFalse(screen.getPixel(9, 0, 1));
+        assertFalse(screen.getPixel(10, 0, 1));
+        assertFalse(screen.getPixel(11, 0, 1));
+        assertFalse(screen.getPixel(12, 0, 1));
+        assertFalse(screen.getPixel(13, 0, 1));
+        assertFalse(screen.getPixel(14, 0, 1));
+        assertFalse(screen.getPixel(15, 0, 1));
+    }
+
+    @Test
+    public void testDrawSpriteNormalBitplane3IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x01, 0x0201);
+        memory.write(0xAA, 0x5000);
+        memory.write(0x55, 0x5001);
+
+        cpu.index = 0x5000;
+        cpu.bitplane = 3;
+        cpu.fetchIncrementExecute();
+
+        // First bitplane pattern
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+
+        // Second bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertTrue(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+        assertTrue(screen.getPixel(5, 0, 2));
+        assertFalse(screen.getPixel(6, 0, 2));
+        assertTrue(screen.getPixel(7, 0, 2));
+    }
+
+    @Test
+    public void testDrawSpriteExtendedBitplane3IntegrationCorrect() throws IOException, FontFormatException {
+        setUpCanvas();
+        cpu = new CentralProcessingUnit(memory, keyboardMock, screen);
+        cpu.enableExtendedMode();
+
+        memory.write(0xD0, 0x0200);
+        memory.write(0x00, 0x0201);
+
+        memory.write(0xAA, 0x5000);
+        memory.write(0x55, 0x5001);
+        memory.write(0xAA, 0x5002);
+        memory.write(0x55, 0x5003);
+        memory.write(0xAA, 0x5004);
+        memory.write(0x55, 0x5005);
+        memory.write(0xAA, 0x5006);
+        memory.write(0x55, 0x5007);
+        memory.write(0xAA, 0x5008);
+        memory.write(0x55, 0x5009);
+        memory.write(0xAA, 0x500A);
+        memory.write(0x55, 0x500B);
+        memory.write(0xAA, 0x500C);
+        memory.write(0x55, 0x500D);
+        memory.write(0xAA, 0x500E);
+        memory.write(0x55, 0x500F);
+
+        memory.write(0x55, 0x5010);
+        memory.write(0xAA, 0x5011);
+        memory.write(0x55, 0x5012);
+        memory.write(0xAA, 0x5013);
+        memory.write(0x55, 0x5014);
+        memory.write(0xAA, 0x5015);
+        memory.write(0x55, 0x5016);
+        memory.write(0xAA, 0x5017);
+        memory.write(0x55, 0x5018);
+        memory.write(0xAA, 0x5019);
+        memory.write(0x55, 0x501A);
+        memory.write(0xAA, 0x501B);
+        memory.write(0x55, 0x501C);
+        memory.write(0xAA, 0x501D);
+        memory.write(0x55, 0x501E);
+        memory.write(0xAA, 0x501F);
+
+        memory.write(0x55, 0x5020);
+        memory.write(0xAA, 0x5021);
+        memory.write(0x55, 0x5022);
+        memory.write(0xAA, 0x5023);
+        memory.write(0x55, 0x5024);
+        memory.write(0xAA, 0x5025);
+        memory.write(0x55, 0x5026);
+        memory.write(0xAA, 0x5027);
+        memory.write(0x55, 0x5028);
+        memory.write(0xAA, 0x5029);
+        memory.write(0x55, 0x502A);
+        memory.write(0xAA, 0x502B);
+        memory.write(0x55, 0x502C);
+        memory.write(0xAA, 0x502D);
+        memory.write(0x55, 0x502E);
+        memory.write(0xAA, 0x502F);
+
+        memory.write(0xAA, 0x5030);
+        memory.write(0x55, 0x5031);
+        memory.write(0xAA, 0x5032);
+        memory.write(0x55, 0x5033);
+        memory.write(0xAA, 0x5034);
+        memory.write(0x55, 0x5035);
+        memory.write(0xAA, 0x5036);
+        memory.write(0x55, 0x5037);
+        memory.write(0xAA, 0x5038);
+        memory.write(0x55, 0x5039);
+        memory.write(0xAA, 0x503A);
+        memory.write(0x55, 0x503B);
+        memory.write(0xAA, 0x503C);
+        memory.write(0x55, 0x503D);
+        memory.write(0xAA, 0x503E);
+        memory.write(0x55, 0x503F);
+
+        cpu.index = 0x5000;
+        cpu.bitplane = 3;
+        cpu.fetchIncrementExecute();
+
+        // Second bitplane pattern
+        assertTrue(screen.getPixel(0, 0, 1));
+        assertFalse(screen.getPixel(1, 0, 1));
+        assertTrue(screen.getPixel(2, 0, 1));
+        assertFalse(screen.getPixel(3, 0, 1));
+        assertTrue(screen.getPixel(4, 0, 1));
+        assertFalse(screen.getPixel(5, 0, 1));
+        assertTrue(screen.getPixel(6, 0, 1));
+        assertFalse(screen.getPixel(7, 0, 1));
+        assertFalse(screen.getPixel(8, 0, 1));
+        assertTrue(screen.getPixel(9, 0, 1));
+        assertFalse(screen.getPixel(10, 0, 1));
+        assertTrue(screen.getPixel(11, 0, 1));
+        assertFalse(screen.getPixel(12, 0, 1));
+        assertTrue(screen.getPixel(13, 0, 1));
+        assertFalse(screen.getPixel(14, 0, 1));
+        assertTrue(screen.getPixel(15, 0, 1));
+
+        // First bitplane pattern
+        assertFalse(screen.getPixel(0, 0, 2));
+        assertTrue(screen.getPixel(1, 0, 2));
+        assertFalse(screen.getPixel(2, 0, 2));
+        assertTrue(screen.getPixel(3, 0, 2));
+        assertFalse(screen.getPixel(4, 0, 2));
+        assertTrue(screen.getPixel(5, 0, 2));
+        assertFalse(screen.getPixel(6, 0, 2));
+        assertTrue(screen.getPixel(7, 0, 2));
+        assertTrue(screen.getPixel(8, 0, 2));
+        assertFalse(screen.getPixel(9, 0, 2));
+        assertTrue(screen.getPixel(10, 0, 2));
+        assertFalse(screen.getPixel(11, 0, 2));
+        assertTrue(screen.getPixel(12, 0, 2));
+        assertFalse(screen.getPixel(13, 0, 2));
+        assertTrue(screen.getPixel(14, 0, 2));
+        assertFalse(screen.getPixel(15, 0, 2));
+    }
+
+    @Test
     public void testKillInvoked() {
         cpu.operand = 0xFD;
         cpu.executeInstruction(0x0);
@@ -1168,7 +1520,7 @@ public class CentralProcessingUnitTest
         cpu.operand = 0xFF;
         cpu.executeInstruction(0x0);
         verify(screenMock, times(1)).setExtendedScreenMode();
-        assertEquals(CentralProcessingUnit.MODE_EXTENDED, cpu.mode);
+        assertEquals(MODE_EXTENDED, cpu.mode);
     }
 
     @Test
@@ -1282,11 +1634,16 @@ public class CentralProcessingUnitTest
     }
 
     @Test
-    public void testWaitForKeypress() {
+    public void testIsAwaitingKeypressFalseAtInit() {
+        assertFalse(cpu.isAwaitingKeypress());
+    }
+
+    @Test
+    public void testWaitForKeypressSetsAwaitingKeypress() {
         int register = 1;
         cpu.operand = register << 8;
         cpu.waitForKeypress();
-        assertEquals(9, cpu.v[register]);
+        assertTrue(cpu.isAwaitingKeypress());
     }
     
     @Test

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/KeyboardTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/KeyboardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2018 Craig Thomas
+ * Copyright (C) 2013-2024 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.chip8java.emulator.components;
@@ -49,8 +49,8 @@ public class KeyboardTest
 
     @Test
     public void testGetDebugKey() {
-        keyboard.debugKeyPressed = 1;
-        assertEquals(1, keyboard.getDebugKey());
+        keyboard.rawKeyPressed = 1;
+        assertEquals(1, keyboard.getRawKeyPressed());
     }
 
     @Test
@@ -65,12 +65,5 @@ public class KeyboardTest
         when(event.getKeyCode()).thenReturn(KeyEvent.VK_2);
         keyboard.keyPressed(event);
         assertEquals(2, keyboard.currentKeyPressed);
-    }
-
-    @Test
-    public void testEmulatorKilledWhenQuitPressed() {
-        when(event.getKeyCode()).thenReturn(Keyboard.CHIP8_QUIT);
-        keyboard.keyPressed(event);
-        Mockito.verify(emulator, times(1)).kill();
     }
 }


### PR DESCRIPTION
This PR solves a few bugs with the emulator in its current state that are not captured by an issue. First, the emulator loop would not allow for the escape key to be pressed while waiting for a keypress. This issue also extended to debug keys in general. Pressing the escape key would dismiss the emulator window, but would not stop the emulator process. This has been fixed.

Second, several unit tests have been added to cover test cases relating to bitplane drawing. 

Unit tests and integration tests updated to catch new conditions.