### PR TITLE
Implement logic quirks flag

### DIFF
--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnit.java
@@ -109,6 +109,9 @@ public class CentralProcessingUnit extends Thread
     // Whether shift quirks are enabled
     private boolean shiftQuirks = false;
 
+    // Whether logic quirks are enabled
+    private boolean logicQuirks = false;
+
     CentralProcessingUnit(Memory memory, Keyboard keyboard, Screen screen) {
         this.random = new Random();
         this.memory = memory;
@@ -141,6 +144,15 @@ public class CentralProcessingUnit extends Thread
      */
     public void setShiftQuirks(boolean enableQuirk) {
         shiftQuirks = enableQuirk;
+    }
+
+    /**
+     * Sets the logicQuirks to true or false.
+     *
+     * @param enableQuirk a boolean enabling logic quirks or disabling logic quirks
+     */
+    public void setLogicQuirks(boolean enableQuirk) {
+        logicQuirks = enableQuirk;
     }
 
     /**
@@ -611,6 +623,9 @@ public class CentralProcessingUnit extends Thread
         int x = (operand & 0x0F00) >> 8;
         int y = (operand & 0x00F0) >> 4;
         v[x] |= v[y];
+        if (logicQuirks) {
+            v[0xF] = 0;
+        }
         lastOpDesc = "OR V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
@@ -623,6 +638,9 @@ public class CentralProcessingUnit extends Thread
         int x = (operand & 0x0F00) >> 8;
         int y = (operand & 0x00F0) >> 4;
         v[x] &= v[y];
+        if (logicQuirks) {
+            v[0xF] = 0;
+        }
         lastOpDesc = "AND V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 
@@ -635,6 +653,9 @@ public class CentralProcessingUnit extends Thread
         int x = (operand & 0x0F00) >> 8;
         int y = (operand & 0x00F0) >> 4;
         v[x] ^= v[y];
+        if (logicQuirks) {
+            v[0xF] = 0;
+        }
         lastOpDesc = "XOR V" + toHex(x, 1) + ", V" + toHex(y, 1);
     }
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
@@ -54,7 +54,7 @@ public class Emulator
      * screen scale, a cycle time of 0, a null rom, and trace mode off.
      */
     public Emulator() {
-        this(1, 0, null, false, "#000000", "#666666", "#BBBBBB", "#FFFFFF", false);
+        this(1, 0, null, false, "#000000", "#666666", "#BBBBBB", "#FFFFFF", false, false);
     }
 
     /**
@@ -69,6 +69,7 @@ public class Emulator
      * @param color2 the bitplane 2 color
      * @param color3 the bitplane 3 color
      * @param shiftQuirks whether to enable shift quirks or not
+     * @param logicQuirks whether to enable logic quirks or not
      */
     public Emulator(
             int scale,
@@ -79,7 +80,8 @@ public class Emulator
             String color1,
             String color2,
             String color3,
-            boolean shiftQuirks
+            boolean shiftQuirks,
+            boolean logicQuirks
     ) {
         if (color0.length() != 6) {
             System.out.println("color_0 parameter must be 6 characters long");
@@ -139,6 +141,7 @@ public class Emulator
         screen = new Screen(scale, converted_color0, converted_color1, converted_color2, converted_color3);
         cpu = new CentralProcessingUnit(memory, keyboard, screen);
         cpu.setShiftQuirks(shiftQuirks);
+        cpu.setLogicQuirks(logicQuirks);
 
         // Load the font file into memory
         InputStream fontFileStream = IO.openInputStreamFromResource(FONT_FILE);

--- a/src/main/java/ca/craigthomas/chip8java/emulator/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/runner/Arguments.java
@@ -38,4 +38,7 @@ public class Arguments
 
     @Parameter(names={"--shift_quirks"}, description="enable shift quirks")
     public Boolean shiftQuirks = false;
+
+    @Parameter(names={"--logic_quirks"}, description="enable logic quirks")
+    public Boolean logicQuirks = false;
 }

--- a/src/main/java/ca/craigthomas/chip8java/emulator/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/runner/Runner.java
@@ -36,7 +36,8 @@ public class Runner
                 args.color1,
                 args.color2,
                 args.color3,
-                args.shiftQuirks
+                args.shiftQuirks,
+                args.logicQuirks
         );
         emulator.start();
     }

--- a/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
+++ b/src/test/java/ca/craigthomas/chip8java/emulator/components/CentralProcessingUnitTest.java
@@ -311,6 +311,18 @@ public class CentralProcessingUnitTest
     }
 
     @Test
+    public void testLogicalOrLogicQuirksClearsFlag() {
+        cpu.v[1] = 0;
+        cpu.v[2] = 1;
+        cpu.v[0xF] = 1;
+        cpu.operand = 0x8121;
+        cpu.setLogicQuirks(true);
+        cpu.logicalOr();
+        assertEquals(1, cpu.v[1]);
+        assertEquals(0, cpu.v[0xF]);
+    }
+
+    @Test
     public void testLogicalAnd() {
         for (int source = 0; source < 0x10; source++) {
             for (int target = 0; target < 0x10; target++) {
@@ -331,6 +343,18 @@ public class CentralProcessingUnitTest
     }
 
     @Test
+    public void testLogicalAndLogicQuirksClearsFlag() {
+        cpu.v[1] = 0;
+        cpu.v[2] = 1;
+        cpu.v[0xF] = 1;
+        cpu.operand = 0x8122;
+        cpu.setLogicQuirks(true);
+        cpu.logicalAnd();
+        assertEquals(0, cpu.v[1]);
+        assertEquals(0, cpu.v[0xF]);
+    }
+
+    @Test
     public void testExclusiveOr() {
         for (int source = 0; source < 0x10; source++) {
             for (int target = 0; target < 0x10; target++) {
@@ -348,6 +372,18 @@ public class CentralProcessingUnitTest
                 }
             }
         }
+    }
+
+    @Test
+    public void testExclusiveOrLogicQuirksClearsFlag() {
+        cpu.v[1] = 1;
+        cpu.v[2] = 1;
+        cpu.v[0xF] = 1;
+        cpu.operand = 0x8123;
+        cpu.setLogicQuirks(true);
+        cpu.exclusiveOr();
+        assertEquals(0, cpu.v[1]);
+        assertEquals(0, cpu.v[0xF]);
     }
 
     @Test


### PR DESCRIPTION
This PR adds a logic quirks flag to the emulator. Enabling logic quirks will always ensure that the `F` register is always cleared following a logical operation. Unit tests added to catch new condition. This PR closes #37 
