### PR TITLE
Add CPU instruction limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An Octo compatible XO Chip, Super Chip, and Chip 8 emulator.
    2. [Starting the Emulator](#starting-the-emulator)
    3. [Running a ROM](#running-a-rom)
    4. [Screen Scale](#screen-scale)
-   5. [Execution Delay](#execution-delay)
+   5. [Instructions Per Second](#instructions-per-second)
    6. [Quirks Modes](#quirks-modes)
       1. [Shift Quirks](#shift-quirks)
       2. [Index Quirks](#index-quirks)
@@ -125,18 +125,12 @@ at 1x scale is 64 x 32):
 The command above will scale the window so that it is 10 times the normal
 size. 
 
-### Execution Delay
+### Instructions Per Second
 
-You may also wish to experiment with the `--delay` switch, which instructs
-the emulator to add a delay to every operation that is executed. For example,
-
-    java -jar emulator-2.0.0-all.jar /path/to/rom/filename --delay 10
-
-The command above will add a 10 ms delay to every opcode that is executed.
-This is useful for very fast computers (note that it is difficult to find
-information regarding opcode execution times, as such, I have not attempted
-any fancy timing mechanisms to ensure that instructions are executed in a
-set amount of time).
+The `--ticks` switch will limit the number of instructions per second that the 
+emulator is allowed to run. By default, the value is set to 1,000. Minimum values 
+are 200. Use this switch to adjust the running time of ROMs that execute too quickly. 
+For simplicity, each instruction is assumed to take the same amount of time.
 
 ### Quirks Modes
 

--- a/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/components/Emulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Craig Thomas
+ * Copyright (C) 2013-2025 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.chip8java.emulator.components;
@@ -61,7 +61,7 @@ public class Emulator
      * Initializes an Emulator based on the parameters passed.
      *
      * @param scale the screen scaling to apply to the emulator window
-     * @param cycleTime the cycle time delay for the emulator
+     * @param maxTicks the maximum number of operations per second to execute
      * @param rom the rom filename to load
      * @param memSize4k whether to set memory size to 4k
      * @param color0 the bitplane 0 color
@@ -75,7 +75,7 @@ public class Emulator
      */
     public Emulator(
             int scale,
-            int cycleTime,
+            int maxTicks,
             String rom,
             boolean memSize4k,
             String color0,
@@ -140,7 +140,6 @@ public class Emulator
             System.exit(1);
         }
 
-        cpuCycleTime = cycleTime;
         keyboard = new Keyboard();
         memory = new Memory(memSize4k);
         screen = new Screen(scale, converted_color0, converted_color1, converted_color2, converted_color3);
@@ -150,6 +149,7 @@ public class Emulator
         cpu.setJumpQuirks(jumpQuirks);
         cpu.setIndexQuirks(indexQuirks);
         cpu.setClipQuirks(clipQuirks);
+        cpu.setMaxTicks(maxTicks);
 
         // Load the font file into memory
         InputStream fontFileStream = IO.openInputStreamFromResource(FONT_FILE);
@@ -188,17 +188,12 @@ public class Emulator
                 refreshScreen();
             }
         };
-        timer.scheduleAtFixedRate(timerTask, 0L, 33L);
+        timer.scheduleAtFixedRate(timerTask, 0L, 17L);
 
         while (state != EmulatorState.KILLED) {
             if (state != EmulatorState.PAUSED) {
                 if (!cpu.isAwaitingKeypress()) {
                     cpu.fetchIncrementExecute();
-                    try {
-                        Thread.sleep(cpuCycleTime);
-                    } catch (InterruptedException e) {
-                        LOGGER.warning("CPU sleep interrupted");
-                    }
                 } else {
                     cpu.decodeKeypressAndContinue();
                 }

--- a/src/main/java/ca/craigthomas/chip8java/emulator/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/runner/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Craig Thomas
+ * Copyright (C) 2013-2025 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.chip8java.emulator.runner;
@@ -17,9 +17,6 @@ public class Arguments
 
     @Parameter(names={"--scale"}, description="scale factor")
     public Integer scale = 7;
-
-    @Parameter(names={"--delay"}, description="delay factor")
-    public Integer delay = (int) CentralProcessingUnit.DEFAULT_CPU_CYCLE_TIME;
 
     @Parameter(names={"--mem_size_4k"}, description="sets memory size to 4K (defaults to 64K)")
     public Boolean memSize4k = false;
@@ -50,4 +47,7 @@ public class Arguments
 
     @Parameter(names={"--clip_quirks"}, description="enable clip quirks")
     public Boolean clipQuirks = false;
+
+    @Parameter(names={"--ticks"}, description="how many instructions per seconds are allowed")
+    public int maxTicks = CentralProcessingUnit.DEFAULT_MAX_TICKS;
 }

--- a/src/main/java/ca/craigthomas/chip8java/emulator/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/chip8java/emulator/runner/Runner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Craig Thomas
+ * Copyright (C) 2013-2025 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.chip8java.emulator.runner;
@@ -29,7 +29,7 @@ public class Runner
         /* Create the emulator and start it running */
         Emulator emulator = new Emulator(
                 args.scale,
-                args.delay,
+                args.maxTicks,
                 args.romFile,
                 args.memSize4k,
                 args.color0,


### PR DESCRIPTION
This PR adds a limit on the number of instructions that can be executed per second, instead of implementing an instruction delay. This PR closes #58 
